### PR TITLE
query/ui: Move included tests detection of a change in the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- [api] add the tests_included parameter.
 - [install] split `README.md` in [`README.md`](README.md) and [`CONTRIBUTING.md`](CONTRIBUTING.md).
 - [build] build containers in 2 steps to save space.
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Here is the complexity versus time to merge changes:
 
 ## Components
 
-Monocle supports Github Pull Requests and Gerrit Reviews. Monocle
+Monocle supports GitHub Pull Requests and Gerrit Reviews. Monocle
 provides a set of crawlers designed to fetch Pull Requests and Reviews
-data from the Github or Gerrit APIs and to store changes and changes
+data from the GitHub or Gerrit APIs and to store changes and changes
 related events into Elasticsearch. These changes and events are expose
 via a JSON API. Furthermore Monocle implements ready to use queries
 and a React based web UI.
@@ -50,9 +50,9 @@ To summarize we have the following components in Monocle:
 
 ## Installation
 
-Monocle is in an early phase of developement. Feedback is highly welcome.
+Monocle is in an early phase of development. Feedback is highly welcome.
 
-The process below describes how to index changes from a Github repository, a full Github organisation and Gerrit repositories, and then how to start the web UI to browse metrics using `docker-compose`.
+The process below describes how to index changes from a GitHub repository, a full GitHub organisation and Gerrit repositories, and then how to start the web UI to browse metrics using `docker-compose`.
 
 ### Clone and prepare data directory
 
@@ -68,7 +68,7 @@ $ ln -s docker-compose.yml.img docker-compose.yml
 The `config.yaml` file is used by the crawler and api services.
 
 If you want to crawl GitHub repositories, generate a personal access
-token on Github (w/o any specific rights).
+token on GitHub (w/o any specific rights).
 
 Then create the config file `etc/config.yaml`:
 
@@ -119,12 +119,12 @@ into the `.env` file.
 ### GitHub authentication
 
 If you want to protect the access to your indices, you can require a
-GitHub login to access and the people able to use the indeices will be
+GitHub login to access and the people able to use the indices will be
 the ones listed in the `users` section in `config.yaml`.
 
-Configure the Github Oauth authentication to secure private indexes
+Configure the GitHub Oauth authentication to secure private indexes
 
-1. Create an Oauth APP in your Github user settings page
+1. Create an Oauth APP in your GitHub user settings page
 2. Add "http://$MONOCLE_HOST:9876/api/0/authorize" in "User authorization callback URL"
 3. Save the `CLIENT_ID` and `CLIENT_SECRET` into `.env` as `GITHUB_CLIENT_ID=<CLIENT_ID>` and `GITHUB_CLIENT_SECRET=<CLIENT_SECRET>`.
 

--- a/monocle/db/queries.py
+++ b/monocle/db/queries.py
@@ -23,6 +23,7 @@ from itertools import groupby
 from monocle.utils import dbdate_to_datetime
 from monocle.utils import float_trunc
 from monocle.utils import enhance_changes
+from monocle.utils import Detector
 
 from elasticsearch.helpers import scan as scanner
 from elasticsearch.exceptions import NotFoundError
@@ -89,8 +90,13 @@ def generate_events_filter(params, qfilter):
 
 def generate_changes_filter(params, qfilter):
     state = params.get('state')
+    tests_included = params.get('tests_included')
     if state:
         qfilter.append({"term": {"state": state}})
+    if tests_included:
+        qfilter.append(
+            {"regexp": {"changed_files.path": {'value': Detector.tests_regexp}}}
+        )
 
 
 def generate_filter(repository_fullname, params):

--- a/monocle/db/queries.py
+++ b/monocle/db/queries.py
@@ -22,6 +22,7 @@ from datetime import datetime
 from itertools import groupby
 from monocle.utils import dbdate_to_datetime
 from monocle.utils import float_trunc
+from monocle.utils import enhance_changes
 
 from elasticsearch.helpers import scan as scanner
 from elasticsearch.exceptions import NotFoundError
@@ -544,6 +545,7 @@ def cold_changes(es, index, repository_fullname, params):
     changes_wo_rc = [
         change for change in changes if change['change_id'] in changes_ids_wo_rc
     ]
+    changes_wo_rc = enhance_changes(changes_wo_rc)
     items = sorted(changes_wo_rc, key=lambda x: dbdate_to_datetime(x['created_at']))
     if size:
         items = items[:size]
@@ -578,6 +580,7 @@ def hot_changes(es, index, repository_fullname, params):
     changes = _scan(es, index, repository_fullname, _params)
     for change in changes:
         change['hot_score'] = mapping[change['change_id']]
+    changes = enhance_changes(changes)
     items = sorted(changes, key=lambda x: x['hot_score'], reverse=True)
     if size:
         items = items[:size]
@@ -686,6 +689,7 @@ def last_changes(es, index, repository_fullname, params):
     }
     data = run_query(es, index, body)
     changes = [r['_source'] for r in data['hits']['hits']]
+    changes = enhance_changes(changes)
     return {'items': changes, 'total': data['hits']['total']}
 
 
@@ -720,6 +724,7 @@ def oldest_open_changes(es, index, repository_fullname, params):
     }
     data = run_query(es, index, body)
     changes = [r['_source'] for r in data['hits']['hits']]
+    changes = enhance_changes(changes)
     return {'items': changes, 'total': data['hits']['total']}
 
 
@@ -743,6 +748,7 @@ def changes_and_events(es, index, repository_fullname, params):
     }
     data = run_query(es, index, body)
     changes = [r['_source'] for r in data['hits']['hits']]
+    changes = enhance_changes(changes)
     return {'items': changes, 'total': data['hits']['total']}
 
 

--- a/monocle/main.py
+++ b/monocle/main.py
@@ -116,6 +116,11 @@ def main():
     parser_dbquery.add_argument(
         '--exclude-authors', help='Authors exclude list (comma separated)'
     )
+    parser_dbquery.add_argument(
+        '--tests-included',
+        help='Scope to changes containing tests',
+        action='store_true',
+    )
 
     args = parser.parse_args()
 

--- a/monocle/tests/unit/fixtures/datasets/objects/unit_repo1.json
+++ b/monocle/tests/unit/fixtures/datasets/objects/unit_repo1.json
@@ -13,14 +13,19 @@
     "target_branch": "master",
     "title": "A PR title",
     "text": "The body text of the PR",
-    "additions": 10,
+    "additions": 11,
     "deletions": 5,
-    "changed_files_count": 1,
+    "changed_files_count": 2,
     "changed_files": [
       {
         "additions": 10,
         "deletions": 5,
         "path": "path/to/file1.py"
+      },
+      {
+        "additions": 1,
+        "deletions": 0,
+        "path": "path/to/tests/test_file1.py"
       }
     ],
     "commit_count": 1,

--- a/monocle/tests/unit/test_queries.py
+++ b/monocle/tests/unit/test_queries.py
@@ -246,7 +246,7 @@ class TestQueries(unittest.TestCase):
         ret = self.eldb.run_named_query('changes_and_events', 'unit/repo1', params)
         self.assertEqual(ret['total'], 4)
         change = [c for c in ret['items'] if c['type'] == 'Change'][0]
-        self.assertTrue(change['_tests_included'])
+        self.assertTrue(change['tests_included'])
 
     def test_last_changes(self):
         """
@@ -255,13 +255,13 @@ class TestQueries(unittest.TestCase):
         params = set_params({'state': 'OPEN'})
         ret = self.eldb.run_named_query('last_changes', 'unit/repo[12]', params)
         self.assertEqual(ret['total'], 1)
-        self.assertFalse(ret['items'][0]['_tests_included'])
+        self.assertFalse(ret['items'][0]['tests_included'])
 
         params = set_params({'state': 'MERGED'})
         ret = self.eldb.run_named_query('last_changes', 'unit/repo[12]', params)
         self.assertEqual(ret['total'], 3)
         for change in ret['items']:
-            self.assertIn('_tests_included', list(change.keys()))
+            self.assertIn('tests_included', list(change.keys()))
 
     def test_tests_included_param(self):
         """

--- a/monocle/tests/unit/test_queries.py
+++ b/monocle/tests/unit/test_queries.py
@@ -262,3 +262,14 @@ class TestQueries(unittest.TestCase):
         self.assertEqual(ret['total'], 3)
         for change in ret['items']:
             self.assertIn('_tests_included', list(change.keys()))
+
+    def test_tests_included_param(self):
+        """
+        Test tests_included param: last_changes
+        """
+        params = set_params({'tests_included': True})
+        ret = self.eldb.run_named_query('last_changes', 'unit/repo[12]', params)
+        self.assertEqual(ret['total'], 1, ret)
+        params = set_params({})
+        ret = self.eldb.run_named_query('last_changes', 'unit/repo[12]', params)
+        self.assertEqual(ret['total'], 4, ret)

--- a/monocle/tests/unit/test_queries.py
+++ b/monocle/tests/unit/test_queries.py
@@ -237,3 +237,28 @@ class TestQueries(unittest.TestCase):
             'changes_and_events', 'unit/repo[12]', set_params({})
         )
         self.assertEqual(ret['total'], ret2['total'])
+
+    def test_change_and_events(self):
+        """
+        Test change_and_events query
+        """
+        params = set_params({})
+        ret = self.eldb.run_named_query('changes_and_events', 'unit/repo1', params)
+        self.assertEqual(ret['total'], 4)
+        change = [c for c in ret['items'] if c['type'] == 'Change'][0]
+        self.assertTrue(change['_tests_included'])
+
+    def test_last_changes(self):
+        """
+        Test last_changes query
+        """
+        params = set_params({'state': 'OPEN'})
+        ret = self.eldb.run_named_query('last_changes', 'unit/repo[12]', params)
+        self.assertEqual(ret['total'], 1)
+        self.assertFalse(ret['items'][0]['_tests_included'])
+
+        params = set_params({'state': 'MERGED'})
+        ret = self.eldb.run_named_query('last_changes', 'unit/repo[12]', params)
+        self.assertEqual(ret['total'], 3)
+        for change in ret['items']:
+            self.assertIn('_tests_included', list(change.keys()))

--- a/monocle/utils.py
+++ b/monocle/utils.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import re
 from datetime import datetime
 
 events_list = [
@@ -47,6 +48,30 @@ def dbdate_to_datetime(datestr):
 
 def float_trunc(f, n=2):
     return float(int(f * 10 ** n)) / 10 ** n
+
+
+class Detector(object):
+    tests_re = re.compile(".*[Tt]est.*")
+
+    def is_tests_included(self, change):
+        for file in change['changed_files']:
+            if self.tests_re.match(file['path']):
+                return True
+        return False
+
+    def enhance(self, change):
+        if change['type'] == 'Change':
+            if self.is_tests_included(change):
+                change['_tests_included'] = True
+            else:
+                change['_tests_included'] = False
+        return change
+
+
+def enhance_changes(changes):
+    detector = Detector()
+    changes = list(map(detector.enhance, changes))
+    return changes
 
 
 def set_params(input):

--- a/monocle/utils.py
+++ b/monocle/utils.py
@@ -63,9 +63,9 @@ class Detector(object):
     def enhance(self, change):
         if change['type'] == 'Change':
             if self.is_tests_included(change):
-                change['_tests_included'] = True
+                change['tests_included'] = True
             else:
-                change['_tests_included'] = False
+                change['tests_included'] = False
         return change
 
 

--- a/monocle/utils.py
+++ b/monocle/utils.py
@@ -51,7 +51,8 @@ def float_trunc(f, n=2):
 
 
 class Detector(object):
-    tests_re = re.compile(".*[Tt]est.*")
+    tests_regexp = ".*[Tt]est.*"
+    tests_re = re.compile(tests_regexp)
 
     def is_tests_included(self, change):
         for file in change['changed_files']:
@@ -95,6 +96,7 @@ def set_params(input):
     params['from'] = int(getter('from', 0))
     params['files'] = getter('files', None)
     params['state'] = getter('state', None)
+    params['tests_included'] = getter('tests_included', False)
     params['change_ids'] = getter('change_ids', None)
     params['target_branch'] = getter('target_branch', None)
     if params['change_ids']:

--- a/web/src/components/change.js
+++ b/web/src/components/change.js
@@ -137,7 +137,7 @@ class ChangeTable extends React.Component {
                     </tr> : null
                   }
                   <tr key={5}>
-                    <td align="center">{change.hasTests ? <font color="DarkGreen">Has tests</font> : <font color="red">Does not have tests</font>}</td>
+                    <td align="center">{change._tests_included ? <font color="DarkGreen">Has tests</font> : <font color="red">Does not have tests</font>}</td>
                   </tr>
                   <tr key={6}>
                     <td align="center">{change.hasLinks ? <font color="DarkGreen">Has a potential issue link</font> : <font color="red">Does not have an issue link</font>}</td>

--- a/web/src/components/change.js
+++ b/web/src/components/change.js
@@ -137,7 +137,7 @@ class ChangeTable extends React.Component {
                     </tr> : null
                   }
                   <tr key={5}>
-                    <td align="center">{change._tests_included ? <font color="DarkGreen">Has tests</font> : <font color="red">Does not have tests</font>}</td>
+                    <td align="center">{change.tests_included ? <font color="DarkGreen">Has tests</font> : <font color="red">Does not have tests</font>}</td>
                   </tr>
                   <tr key={6}>
                     <td align="center">{change.hasLinks ? <font color="DarkGreen">Has a potential issue link</font> : <font color="red">Does not have an issue link</font>}</td>

--- a/web/src/reducers/query.js
+++ b/web/src/reducers/query.js
@@ -49,7 +49,6 @@ addStates(initialState, 'merged_changes_by_file_map')
 const enhanceData = (x) => {
   if (x.type === 'Change') {
     x.complexity = x.changed_files_count + x.additions + x.deletions
-    x.hasTests = (x.changed_files.filter(x => x.path.match(/.*[/].*test/i)).length !== 0)
     x.hasLinks = x.text && x.text.match(/https?:\/\/.*\/.*|#[0-9]+/i)
   }
 }


### PR DESCRIPTION
Detection is done during the query. This will add flexibility for later
as the Detector could be improved to be configurable by projects.

The Detector could also serve to build EL queries to filter on changes
having tests (according to project config)

Fix #150