### PR TITLE
Fix ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- [web] carry search params in links inside complexity graphs.
 - [web] sync between exclude_authors search param and filter field.
 - [web] passing `REACT_APP_API_URL` in container image mode.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- [web] make the authors and repos pie charts clickable.
 - [api] add the tests_included parameter.
 - [install] split `README.md` in [`README.md`](README.md) and [`CONTRIBUTING.md`](CONTRIBUTING.md).
 - [build] build containers in 2 steps to save space.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
+- [web] do not use the Treemap anymore as it is not consistent in the changes view.
+
 ### Fixed
 
 - [web] passing `REACT_APP_API_URL` in container image mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- [web] sync between exclude_authors search param and filter field.
 - [web] passing `REACT_APP_API_URL` in container image mode.
 
 ##  [0.3] - 2020-05-01

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -244,10 +244,12 @@ class MergedChangesView extends React.Component {
           <Row>
             <Col>
               <CAuthorsMergedPie
+                history={this.props.history}
                 index={this.props.match.params.index} />
             </Col>
             <Col>
               <CReposMergedPie
+                history={this.props.history}
                 index={this.props.match.params.index} />
             </Col>
           </Row>
@@ -290,10 +292,12 @@ class OpenChangesView extends React.Component {
           <Row>
             <Col>
               <CAuthorsOpenedPie
+                history={this.props.history}
                 index={this.props.match.params.index} />
             </Col>
             <Col>
               <CReposOpenedPie
+                history={this.props.history}
                 index={this.props.match.params.index} />
             </Col>
           </Row>

--- a/web/src/components/authors_merged_pie.js
+++ b/web/src/components/authors_merged_pie.js
@@ -63,6 +63,8 @@ class AuthorsMergedPie extends BaseQueryComponent {
                 <Row>
                   <Col>
                     <Pie
+                      field="authors"
+                      history={this.props.history}
                       data={this.props.authors_top_merged_result}
                     />
                   </Col>

--- a/web/src/components/authors_opened_pie.js
+++ b/web/src/components/authors_opened_pie.js
@@ -63,6 +63,8 @@ class AuthorsOpenedPie extends BaseQueryComponent {
                 <Row>
                   <Col>
                     <Pie
+                      field="authors"
+                      history={this.props.history}
                       data={this.props.authors_top_opened_result}
                     />
                   </Col>

--- a/web/src/components/changes.js
+++ b/web/src/components/changes.js
@@ -34,7 +34,7 @@ import {
   ErrorBox,
   changeUrl,
   addUrlField,
-  newRelativeUrl,
+  indexUrl,
   mapDispatchToProps,
   addMap,
   chooseBadgeStyle
@@ -42,10 +42,6 @@ import {
 
 import ComplexityGraph from './complexity_graph'
 import DurationComplexityGraph from './duration_complexity_graph'
-import {
-  COpenedFilesTreeMap,
-  CMergedFilesTreeMap
-} from './files_treemap'
 
 class RepoChangesTable extends React.Component {
   render () {
@@ -325,7 +321,7 @@ class LastChanges extends BaseQueryComponent {
                     <ChangesTable
                       index={this.props.index}
                       data={data.merged_changes}
-                      title={<Link to={newRelativeUrl('/merged-changes')}>Recently Merged Changes</Link>}
+                      title={<Link to={indexUrl(this.props.index, '/merged-changes')}>Recently Merged Changes</Link>}
                       merged={true}
                       duration={true}
                     />
@@ -337,7 +333,7 @@ class LastChanges extends BaseQueryComponent {
                     <ChangesTable
                       index={this.props.index}
                       data={data.opened_changes}
-                      title={<Link to={newRelativeUrl('/opened-changes')}>Recently Opened Changes</Link>}
+                      title={<Link to={indexUrl(this.props.index, '/opened-changes')}>Recently Opened Changes</Link>}
                       created={true}
                       mergeable={true}
                       approval={true}
@@ -383,14 +379,6 @@ class AbstractLastChanges extends BaseQueryComponent {
       const LocalComplexityGraph = this.state.complexityGraph
       return (
         <React.Fragment>
-          <Row>
-            <Col>
-              {this.state.merged ? <CMergedFilesTreeMap index={this.props.index} />
-                : <COpenedFilesTreeMap index={this.props.index} />
-              }
-            </Col>
-          </Row>
-          <Row><Col><p /></Col></Row>
           <Row>
             <Col>
               <ChangesTable
@@ -513,7 +501,7 @@ class AbandonedChanges extends BaseQueryComponent {
         <ChangesTable
           index={this.props.index}
           data={data}
-          title={<Link to={newRelativeUrl('/abandoned-changes')}>Last Abandoned Changes</Link>}
+          title={<Link to={indexUrl(this.props.index, '/abandoned-changes')}>Last Abandoned Changes</Link>}
           created={true}
           duration={true}
         />

--- a/web/src/components/common.js
+++ b/web/src/components/common.js
@@ -33,17 +33,17 @@ function changeUrl (index, x, name = null) {
 }
 
 function addUrlField (field, value) {
-  var url = new URL(window.location.href)
+  const url = new URL(window.location.href)
 
   url.searchParams.set(field, value)
 
   return url.pathname + url.search
 }
 
-function newRelativeUrl (dest) {
-  var url = new URL(window.location.href)
+function indexUrl (index, dest) {
+  const url = new URL(window.location.href)
 
-  url.pathname += dest
+  url.pathname = `/${index}${dest}`
   return url.search ? url.pathname + url.search : url.pathname
 }
 
@@ -218,7 +218,7 @@ export {
   BaseQueryComponent,
   changeUrl,
   addUrlField,
-  newRelativeUrl,
+  indexUrl,
   addS,
   addMap,
   mapDispatchToProps,

--- a/web/src/components/complexity_graph.js
+++ b/web/src/components/complexity_graph.js
@@ -31,7 +31,7 @@ class ComplexityGraph extends React.Component {
   }
 
   handleClick (item) {
-    this.props.history.push('/' + this.props.index + '/change/' + item.change_id)
+    this.props.history.push('/' + this.props.index + '/change/' + item.change_id + window.location.search)
   }
 
   getData (func, x) {

--- a/web/src/components/filtersform.js
+++ b/web/src/components/filtersform.js
@@ -142,7 +142,7 @@ class FiltersForm extends React.Component {
       repository: '',
       branch: '',
       files: '',
-      exclude_authors: '',
+      excludeAuthors: '',
       authors: ''
     }
     if (this.props.history !== undefined) {
@@ -214,7 +214,7 @@ class FiltersForm extends React.Component {
       repository: this.state.repository,
       branch: this.state.branch,
       files: this.state.files,
-      exclude_authors: this.state.exclude_authors,
+      exclude_authors: this.state.excludeAuthors,
       authors: this.state.authors
     })
     event.preventDefault()
@@ -260,9 +260,9 @@ class FiltersForm extends React.Component {
                 <Form.Group controlId='formExcludeAuthorsInput'>
                   <Form.Control
                     type='text'
-                    value={this.state.exclude_authors}
+                    value={this.state.excludeAuthors}
                     placeholder="Exclude Authors"
-                    onChange={v => this.handleChange('exclude_authors', v)}
+                    onChange={v => this.handleChange('excludeAuthors', v)}
                   />
                 </Form.Group>
               </Col>

--- a/web/src/components/pie.js
+++ b/web/src/components/pie.js
@@ -19,6 +19,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import {
+  addUrlField,
   ErrorBox
 } from './common'
 
@@ -50,6 +51,13 @@ class Pie extends React.Component {
     return pieData
   }
 
+  handleClick (obj, elems) {
+    if (obj.props.field && obj.props.history && elems && elems.length > 0 && elems[0]._index < obj.props.data.items.length) {
+      const key = obj.props.data.items[elems[0]._index].key
+      obj.props.history.push(addUrlField(obj.props.field, key))
+    }
+  }
+
   render () {
     const data = this.prepareDataSet(this.props.data)
     if (!data) {
@@ -57,11 +65,15 @@ class Pie extends React.Component {
         error="No data for Pie"
       />
     }
-    return <BasePie data={data} />
+    return <BasePie
+      getElementsAtEvent={elems => this.handleClick(this, elems)}
+      data={data} />
   }
 }
 
 Pie.propTypes = {
+  history: PropTypes.object,
+  field: PropTypes.string,
   data: PropTypes.shape({
     items: PropTypes.array.isRequired,
     total_hits: PropTypes.number.isRequired

--- a/web/src/components/repos_merged_pie.js
+++ b/web/src/components/repos_merged_pie.js
@@ -63,6 +63,8 @@ class ReposMergedPie extends BaseQueryComponent {
                 <Row>
                   <Col>
                     <Pie
+                      field="repository"
+                      history={this.props.history}
                       data={this.props.repos_top_merged_result}
                     />
                   </Col>

--- a/web/src/components/repos_opened_pie.js
+++ b/web/src/components/repos_opened_pie.js
@@ -63,6 +63,8 @@ class ReposOpenedPie extends BaseQueryComponent {
                 <Row>
                   <Col>
                     <Pie
+                      field="repository"
+                      history={this.props.history}
                       data={this.props.repos_top_opened_result}
                     />
                   </Col>


### PR DESCRIPTION
- [web] fix links in the /people and /changes pages
- [web] make the authors and repos pie charts clickable.
- [web] do not use the Treemap anymore as it is not consistent in the changes view.
- [web] carry search params in links inside complexity graphs.
- [web] sync between exclude_authors search param and filter field.
