### PR TITLE
Improve support for issue tracker links detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - [web] make the authors and repos pie charts clickable.
+- [api] add the has-issue-tracker-links parameter.
 - [api] add the tests_included parameter.
 - [install] split `README.md` in [`README.md`](README.md) and [`CONTRIBUTING.md`](CONTRIBUTING.md).
 - [build] build containers in 2 steps to save space.
@@ -17,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - [crawler] log error before retrying GitHub graphql queries.
 - [backend] upgraded to Elasticsearch 6.8.8.
+- [web, api] improve and move issue tracker links detection from ui to the backend.
 - [web] add a new favicon.ico.
 - [web] split top page into a people and changes pages.
 - [dev] distribute 2 docker-compose.yml files: one for dev and one using images from docker hub.

--- a/monocle/db/db.py
+++ b/monocle/db/db.py
@@ -87,8 +87,14 @@ class ELmonocleDB:
                     "type": {"type": "keyword"},
                     "number": {"type": "keyword"},
                     "change_id": {"type": "keyword"},
-                    "title": {"type": "text"},
-                    "text": {"type": "text"},
+                    "title": {
+                        "type": "text",
+                        "fields": {"keyword": {"type": "keyword"}},
+                    },
+                    "text": {
+                        "type": "text",
+                        "fields": {"keyword": {"type": "keyword"}},
+                    },
                     "url": {"type": "keyword"},
                     "commit_count": {"type": "integer"},
                     "additions": {"type": "integer"},

--- a/monocle/db/queries.py
+++ b/monocle/db/queries.py
@@ -99,17 +99,18 @@ def generate_changes_filter(params, qfilter):
             {"regexp": {"changed_files.path": {'value': Detector.tests_regexp}}}
         )
     if has_issue_tracker_links:
-        value = Detector().get_issue_tracker_regexp()
-        qfilter.append(
-            {
-                "bool": {
-                    "should": [
-                        {"regexp": {"text.keyword": {'value': value}}},
-                        {"regexp": {"title.keyword": {'value': value}}},
-                    ]
+        value = Detector().get_issue_tracker_regexp(style=has_issue_tracker_links)
+        if value:
+            qfilter.append(
+                {
+                    "bool": {
+                        "should": [
+                            {"regexp": {"text.keyword": {'value': value}}},
+                            {"regexp": {"title.keyword": {'value': value}}},
+                        ]
+                    }
                 }
-            }
-        )
+            )
 
 
 def generate_filter(repository_fullname, params):

--- a/monocle/db/queries.py
+++ b/monocle/db/queries.py
@@ -91,11 +91,24 @@ def generate_events_filter(params, qfilter):
 def generate_changes_filter(params, qfilter):
     state = params.get('state')
     tests_included = params.get('tests_included')
+    has_issue_tracker_links = params.get('has_issue_tracker_links')
     if state:
         qfilter.append({"term": {"state": state}})
     if tests_included:
         qfilter.append(
             {"regexp": {"changed_files.path": {'value': Detector.tests_regexp}}}
+        )
+    if has_issue_tracker_links:
+        value = Detector().get_issue_tracker_regexp()
+        qfilter.append(
+            {
+                "bool": {
+                    "should": [
+                        {"regexp": {"text.keyword": {'value': value}}},
+                        {"regexp": {"title.keyword": {'value': value}}},
+                    ]
+                }
+            }
         )
 
 

--- a/monocle/main.py
+++ b/monocle/main.py
@@ -121,6 +121,11 @@ def main():
         help='Scope to changes containing tests',
         action='store_true',
     )
+    parser_dbquery.add_argument(
+        '--has-issue-tracker-links',
+        help='Scope to changes containing issue tracker links',
+        action='store_true',
+    )
 
     args = parser.parse_args()
 

--- a/monocle/main.py
+++ b/monocle/main.py
@@ -123,8 +123,8 @@ def main():
     )
     parser_dbquery.add_argument(
         '--has-issue-tracker-links',
-        help='Scope to changes containing issue tracker links',
-        action='store_true',
+        help='Scope to changes containing an issue tracker link',
+        choices=['generic', 'github.com', 'altassian.net'],
     )
 
     args = parser.parse_args()

--- a/monocle/tests/unit/fixtures/datasets/objects/unit_repo1.json
+++ b/monocle/tests/unit/fixtures/datasets/objects/unit_repo1.json
@@ -12,7 +12,7 @@
     "branch": "feature-1",
     "target_branch": "master",
     "title": "A PR title",
-    "text": "The body text of the PR",
+    "text": "The body text of the PR\nThis close issue #42",
     "additions": 11,
     "deletions": 5,
     "changed_files_count": 2,

--- a/monocle/tests/unit/test_detector.py
+++ b/monocle/tests/unit/test_detector.py
@@ -24,6 +24,25 @@ from monocle.utils import Detector
 
 
 class TestDetector(unittest.TestCase):
+    def test_generic_issue_tracker_links(self):
+        """
+        Test Detector tracker links: generic
+        """
+        d = Detector()
+
+        change = {
+            'title': 'A text PR',
+            'text': 'This PR fix the issue https://bugs.demo.net/1749',
+        }
+
+        # Test #1 style
+        d.issue_tracker_extract_links(change)
+        self.assertTrue(change['has_issue_tracker_links'])
+        expected = [['https://bugs.demo.net/1749', 'https://bugs.demo.net/1749']]
+        ddiff = DeepDiff(change['issue_tracker_links'], expected)
+        if ddiff:
+            raise DiffException(ddiff)
+
     def test_github_issue_tracker_links(self):
         """
         Test Detector tracker links: GitHub.com
@@ -90,6 +109,32 @@ class TestDetector(unittest.TestCase):
         change['text'] = 'This fix GH-12'
         d.issue_tracker_extract_links(change)
         expected = [['GH-12', 'https://github.com/change-metrics/monocle/issues/12']]
+        ddiff = DeepDiff(change['issue_tracker_links'], expected)
+        if ddiff:
+            raise DiffException(ddiff)
+
+    def test_altassian_net_issue_tracker_links(self):
+        """
+        Test Detector tracker links: altassian.net
+        """
+        d = Detector()
+
+        change = {
+            'repository_prefix': 'change-metrics',
+            'repository_shortname': 'monocle',
+            'title': 'A text PR',
+            'text': 'This PR fix the issue https://yoyo.atlassian.net/browse/YOYO-1749',
+        }
+
+        # Test #1 style
+        d.issue_tracker_extract_links(change)
+        self.assertTrue(change['has_issue_tracker_links'])
+        expected = [
+            [
+                'https://yoyo.atlassian.net/browse/YOYO-1749',
+                'https://yoyo.atlassian.net/browse/YOYO-1749',
+            ]
+        ]
         ddiff = DeepDiff(change['issue_tracker_links'], expected)
         if ddiff:
             raise DiffException(ddiff)

--- a/monocle/tests/unit/test_detector.py
+++ b/monocle/tests/unit/test_detector.py
@@ -1,0 +1,95 @@
+# Monocle.
+# Copyright (C) 2020 Monocle authors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+import unittest
+
+from deepdiff import DeepDiff
+from .common import DiffException
+
+from monocle.utils import Detector
+
+
+class TestDetector(unittest.TestCase):
+    def test_github_issue_tracker_links(self):
+        """
+        Test Detector tracker links: GitHub.com
+        """
+        d = Detector()
+
+        change = {
+            'repository_prefix': 'change-metrics',
+            'repository_shortname': 'monocle',
+            'title': 'A text PR',
+            'text': 'This PR fix the issue #1',
+        }
+
+        # Test #1 style
+        d.issue_tracker_extract_links(change)
+        self.assertTrue(change['has_issue_tracker_links'])
+        expected = [['#1', 'https://github.com/change-metrics/monocle/issues/1']]
+        ddiff = DeepDiff(change['issue_tracker_links'], expected)
+        if ddiff:
+            raise DiffException(ddiff)
+
+        change['title'] = 'A PR that fix #1'
+        change['text'] = 'But also fix #2\n and #31'
+
+        d.issue_tracker_extract_links(change)
+        self.assertTrue(change['has_issue_tracker_links'])
+        expected = [
+            ['#1', 'https://github.com/change-metrics/monocle/issues/1'],
+            ['#2', 'https://github.com/change-metrics/monocle/issues/2'],
+            ['#31', 'https://github.com/change-metrics/monocle/issues/31'],
+        ]
+        ddiff = DeepDiff(change['issue_tracker_links'], expected)
+        if ddiff:
+            raise DiffException(ddiff)
+
+        # Test full issue url style
+        change['title'] = 'A test PR'
+        change['text'] = 'This fix https://github.com/change-metrics/monocle/issues/1'
+        d.issue_tracker_extract_links(change)
+        expected = [
+            [
+                'https://github.com/change-metrics/monocle/issues/1',
+                'https://github.com/change-metrics/monocle/issues/1',
+            ]
+        ]
+        ddiff = DeepDiff(change['issue_tracker_links'], expected)
+        if ddiff:
+            raise DiffException(ddiff)
+
+        # Test full issue url style
+        change['text'] = 'This fix change-metrics/cross-repo#12'
+        d.issue_tracker_extract_links(change)
+        expected = [
+            [
+                'change-metrics/cross-repo#12',
+                'https://github.com/change-metrics/cross-repo/issues/12',
+            ]
+        ]
+        ddiff = DeepDiff(change['issue_tracker_links'], expected)
+        if ddiff:
+            raise DiffException(ddiff)
+
+        # Test GH-42 style
+        change['text'] = 'This fix GH-12'
+        d.issue_tracker_extract_links(change)
+        expected = [['GH-12', 'https://github.com/change-metrics/monocle/issues/12']]
+        ddiff = DeepDiff(change['issue_tracker_links'], expected)
+        if ddiff:
+            raise DiffException(ddiff)

--- a/monocle/tests/unit/test_queries.py
+++ b/monocle/tests/unit/test_queries.py
@@ -247,6 +247,11 @@ class TestQueries(unittest.TestCase):
         self.assertEqual(ret['total'], 4)
         change = [c for c in ret['items'] if c['type'] == 'Change'][0]
         self.assertTrue(change['tests_included'])
+        self.assertTrue(change['has_issue_tracker_links'])
+        self.assertListEqual(
+            change['issue_tracker_links'][0],
+            ['#42', 'https://github.com/unit/repo1/issues/42'],
+        )
 
     def test_last_changes(self):
         """
@@ -268,6 +273,17 @@ class TestQueries(unittest.TestCase):
         Test tests_included param: last_changes
         """
         params = set_params({'tests_included': True})
+        ret = self.eldb.run_named_query('last_changes', 'unit/repo[12]', params)
+        self.assertEqual(ret['total'], 1, ret)
+        params = set_params({})
+        ret = self.eldb.run_named_query('last_changes', 'unit/repo[12]', params)
+        self.assertEqual(ret['total'], 4, ret)
+
+    def test_has_issue_tracker_links_param(self):
+        """
+        Test has_issue_tracker_links param: last_changes
+        """
+        params = set_params({'has_issue_tracker_links': True})
         ret = self.eldb.run_named_query('last_changes', 'unit/repo[12]', params)
         self.assertEqual(ret['total'], 1, ret)
         params = set_params({})

--- a/monocle/tests/unit/test_queries.py
+++ b/monocle/tests/unit/test_queries.py
@@ -283,7 +283,7 @@ class TestQueries(unittest.TestCase):
         """
         Test has_issue_tracker_links param: last_changes
         """
-        params = set_params({'has_issue_tracker_links': True})
+        params = set_params({'has_issue_tracker_links': 'github.com'})
         ret = self.eldb.run_named_query('last_changes', 'unit/repo[12]', params)
         self.assertEqual(ret['total'], 1, ret)
         params = set_params({})

--- a/monocle/utils.py
+++ b/monocle/utils.py
@@ -54,11 +54,79 @@ class Detector(object):
     tests_regexp = ".*[Tt]est.*"
     tests_re = re.compile(tests_regexp)
 
+    issue_tracker_links = {
+        # https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls
+        'github.com': [
+            {
+                'regexp': r"https?:\/\/github.com\/[^/]+\/[^/]+\/issues/\d+",
+                'rewrite': None,
+            },
+            {
+                'regexp': r" #[0-9]+",
+                'rewrite': {
+                    'from': re.compile(r" #(?P<id>[0-9]+)"),
+                    'to': "https://github.com/%(repository_prefix)s/%(repository_shortname)s/issues/%%(id)s",
+                },
+            },
+            {
+                'regexp': r"[^/ :]+\/[^/]+#[0-9]+",
+                'rewrite': {
+                    'from': re.compile(
+                        r"(?P<org>[^/ :]+)\/(?P<repo>[^/]+)#(?P<id>[0-9]+)"
+                    ),
+                    'to': "https://github.com/%%(org)s/%%(repo)s/issues/%%(id)s",
+                },
+            },
+            {
+                'regexp': r"GH-[1-9]+",
+                'rewrite': {
+                    'from': re.compile(r"GH-(?P<id>[1-9]+)"),
+                    'to': "https://github.com/%(repository_prefix)s/%(repository_shortname)s/issues/%%(id)s",
+                },
+            },
+        ]
+    }
+
     def is_tests_included(self, change):
         for file in change['changed_files']:
             if self.tests_re.match(file['path']):
                 return True
         return False
+
+    def get_issue_tracker_regexp(self):
+        regexps = []
+        for tracker_regs in self.issue_tracker_links.values():
+            for reg in tracker_regs:
+                regexps.append(".*%s.*" % reg['regexp'].replace('#', r'\#'))
+        regexp = "|".join(regexps)
+        return regexp
+
+    def issue_match_and_rewrite(self, change, field, reg):
+        store = change['issue_tracker_links']
+        r = re.compile(reg['regexp'])
+        matches = r.findall(change[field])
+        for match in matches:
+            if not reg['rewrite']:
+                # This is already a link. Do not rewrite
+                store.append([match, match])
+            else:
+                m = reg['rewrite']['from'].match(match)
+                if m:
+                    # Format rewrite with change attributes
+                    rewrite = reg['rewrite']['to'] % change
+                    # Format rewrite with matched attributes
+                    rewrite = rewrite % m.groupdict()
+                    store.append([match.strip(), rewrite])
+
+    def issue_tracker_extract_links(self, change):
+        change['issue_tracker_links'] = []
+        for tracker_regs in self.issue_tracker_links.values():
+            for reg in tracker_regs:
+                for field in ('title', 'text'):
+                    self.issue_match_and_rewrite(change, field, reg)
+        change['has_issue_tracker_links'] = (
+            True if change['issue_tracker_links'] else False
+        )
 
     def enhance(self, change):
         if change['type'] == 'Change':
@@ -66,6 +134,7 @@ class Detector(object):
                 change['tests_included'] = True
             else:
                 change['tests_included'] = False
+            self.issue_tracker_extract_links(change)
         return change
 
 
@@ -97,6 +166,7 @@ def set_params(input):
     params['files'] = getter('files', None)
     params['state'] = getter('state', None)
     params['tests_included'] = getter('tests_included', False)
+    params['has_issue_tracker_links'] = getter('has_issue_tracker_links', False)
     params['change_ids'] = getter('change_ids', None)
     params['target_branch'] = getter('target_branch', None)
     if params['change_ids']:

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7019,6 +7019,25 @@
         "side-channel": "^1.0.2"
       }
     },
+    "interweave": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/interweave/-/interweave-12.5.0.tgz",
+      "integrity": "sha512-R6PE+FkhexspBwBS9wa+w0ZHORsXpFgDoLTKt+kazZRZVlO9+b0bpOcimMQ77hY+UwcE3eppGqhsNUVi3EfQmQ==",
+      "requires": {
+        "@types/react": "*",
+        "escape-html": "^1.0.3",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "interweave-autolink": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/interweave-autolink/-/interweave-autolink-4.2.1.tgz",
+      "integrity": "sha512-ziSNh+zwScJ9ZLPBeMpKCqqCNbkhfqKKDof4+uU2onPTmWIWJpLqtR8tDSstT9UqLTm3O/z1rgXvnd5hXlol1g==",
+      "requires": {
+        "@types/react": "*",
+        "prop-types": "^15.7.2"
+      }
+    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -6,6 +6,8 @@
     "axios": "^0.19.2",
     "bootstrap": "^4.4.1",
     "chart.js": "^2.9.3",
+    "interweave": "^12.5.0",
+    "interweave-autolink": "^4.2.1",
     "moment": "2.24.0",
     "react": "^16.13.1",
     "react-bootstrap": "^1.0.0",


### PR DESCRIPTION
At indexation ensure text ant title field are also indexed as keyword
to enable regexp search.

In the web API after the EL query for a change enhances the change
with:

- has_issue_tracker_links field: choice 'generic|github.com|altassian.net'
- issue_tracker_links: The list of matchers + replacements

At query time add the has_issue_tracker_links params to scope
on changes having the tracker links.

Add unit tests.

For now only support generic tracker url, github.com and altassian.net