### PR TITLE
[web] improve the /people/ page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - [web] fix the menu header.
 - [web] add a spinner in the LoadingBox.
+- [web] put the new contributors at the end of the /people/ page because the list can be long.
+- [web] make the peer strength graph smaller on the /people/ page.
 - [crawler] log error before retrying GitHub graphql queries.
 - [backend] upgraded to Elasticsearch 6.8.8.
 - [web, api] improve and move issue tracker links detection from ui to the backend.

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -123,14 +123,14 @@ class PeopleView extends React.Component {
         <Row><Col><p></p></Col></Row>
         <Row>
           <Col>
-            <CNewContributorsStats
+            <CAuthorsPeersStats
               index={this.props.match.params.index} />
           </Col>
         </Row>
         <Row><Col><p></p></Col></Row>
         <Row>
           <Col>
-            <CAuthorsPeersStats
+            <CNewContributorsStats
               index={this.props.match.params.index} />
           </Col>
         </Row>

--- a/web/src/components/connection_diagram.js
+++ b/web/src/components/connection_diagram.js
@@ -68,8 +68,8 @@ class ConnectionDiagram extends React.Component {
       componentId={1}
       groupLabels={data.labels}
       groupColors={['#003f5c', '#374c80', '#7a5195', '#bc5090', '#ef5675', '#ff764a', '#ffa600']}
-      outerRadius={270}
-      innerRadius={250}
+      outerRadius={200}
+      innerRadius={170}
       style={graphStyle}
       resizeWithWindow={true}
     />


### PR DESCRIPTION
- put the new contributors at the end of the /people/ page
  because the list can be long.
- make the peer strength graph smaller on the /people/ page.