### PR TITLE
[crawler] improve compliance with GitHub rate limiting rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- [crawler] follow [GitHub abuse rate limits guidelines](https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits):
+  obey to the Retry-After header for the GitHub api calls, sleep 1s
+  between calls and set the User-Agent header to change-metrics/monocle.
 - [compose] allow to configure on which addresses the services are exposed.
 - [web] fix the menu header.
 - [web] add a spinner in the LoadingBox.

--- a/monocle/github/pullrequest.py
+++ b/monocle/github/pullrequest.py
@@ -16,7 +16,6 @@
 
 import logging
 import requests
-import time
 from datetime import datetime
 from time import sleep
 from dataclasses import dataclass
@@ -214,9 +213,6 @@ class PRsFetcher(object):
             self.log.info("Total PRs to fetch: %s" % kwargs['total_prs_count'])
         if 'data' not in data:
             self.log.error('No data collected: %s' % data)
-            if 'message' in data and 'wait a few minutes' in data['message']:
-                self.log.info('sleeping 120s')
-                time.sleep(120)
             return False
         for pr in data['data']['search']['edges']:
             prs.append(pr['node'])


### PR DESCRIPTION
- obey to the Retry-After header
 - set the User-Agent header to change-metrics/monocle
 - sleep 1 sec between calls
