### PR TITLE
api, ui: Fix wrong abandoned ratio + count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- [api] fix buggy ratio when a change is closed then re-opened
 - [web] fix fetching data when changing page.
 - [web] do not recreate menu and filter form if not needed.
 - [api] fix wrong http code return in case of accessing unauthorized index.

--- a/web/src/components/changes_lifecycle.js
+++ b/web/src/components/changes_lifecycle.js
@@ -173,10 +173,10 @@ class ChangesLifeCycleStats extends BaseQueryComponent {
                         {data.ChangeCommitForcePushedEvent.events_count + data.ChangeCommitPushedEvent.events_count} updates of changes
                       </ListGroup.Item>
                       <ListGroup.Item>
-                        <Link to={`/${this.props.index}/abandoned-changes${search}`}>{data.ChangeAbandonedEvent.events_count} changes abandoned: {data.ratios['abandoned/created']}%</Link>
+                        <Link to={`/${this.props.index}/abandoned-changes${search}`}>{data.abandoned} changes abandoned: {data.ratios['abandoned/created']}%</Link>
                       </ListGroup.Item>
                       <ListGroup.Item>
-                        <Link to={`/${this.props.index}/merged-changes${search}`}>{data.ChangeMergedEvent.events_count} changes merged: {data.ratios['merged/created']}%</Link>
+                        <Link to={`/${this.props.index}/merged-changes${search}`}>{data.merged} changes merged: {data.ratios['merged/created']}%</Link>
                       </ListGroup.Item>
                       <ListGroup.Item>
                         Changes with tests: {data.tests}%


### PR DESCRIPTION
When a change is closed and re-opened then the compute of changes
opened + merged + abandoned != changes created.

It was due to the compute method that was based on the events but not
on the status of the change.

Example of change: https://github.com/bitcoin/bitcoin/pull/18863