### PR TITLE
Add authors_histo histgram query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+
+- [web] display active authors histogram in People page
+- [api] add authors_histo and authors_histo_stats queries
+
 ### Changed
 ### Removed
 ### Fixed

--- a/monocle/db/queries.py
+++ b/monocle/db/queries.py
@@ -723,7 +723,7 @@ def authors_histo_stats(es, index, repository_fullname, params):
     ret = {}
     etypes = (
         'ChangeCreatedEvent',
-        "ChangeMergedEvent",
+        "ChangeReviewedEvent",
         "ChangeCommentedEvent",
     )
     for etype in etypes:

--- a/monocle/db/queries.py
+++ b/monocle/db/queries.py
@@ -20,6 +20,7 @@ import statistics
 from copy import deepcopy
 from datetime import datetime
 from itertools import groupby
+from itertools import chain
 from monocle.utils import dbdate_to_datetime
 from monocle.utils import float_trunc
 from monocle.utils import enhance_changes
@@ -37,6 +38,7 @@ public_queries = (
     "count_merged_changes",
     "count_abandoned_changes",
     "events_histo",
+    "authors_histo",
     "repos_top",
     "events_top_authors",
     "changes_top_approval",
@@ -230,33 +232,35 @@ def count_authors(es, index, repository_fullname, params):
     return data['aggregations']['agg1']['value']
 
 
+def set_histo_granularity(duration):
+    # Set resolution by hour if duration <= 1 day (max 24 buckets)
+    if (duration / (24 * 3600)) <= 1:
+        return 'hour'
+    # Set resolution by day if duration <= 1 month (max 31 buckets)
+    if (duration / (24 * 3600 * 31)) <= 1:
+        return 'day'
+    # Set resolution by week if duration <= 6 months (max 24 buckets)
+    if (duration / (24 * 3600 * 31)) <= 6:
+        return 'week'
+    # Set resolution by month if duration <= 2 years (max 24 buckets)
+    if (duration / (24 * 3600 * 31 * 12)) <= 2:
+        return 'month'
+    return 'year'
+
+
+def interval_to_format(interval):
+    if interval == 'hour':
+        return 'HH:mm'
+    if interval == 'day' or interval == 'week':
+        return 'yyyy-MM-dd'
+    if interval == 'month':
+        return 'yyyy-MM'
+    if interval == 'year':
+        return 'yyyy'
+    return 'yyyy-MM-dd HH:mm'
+
+
 def events_histo(es, index, repository_fullname, params):
-    def set_histo_granularity(duration):
-        # Set resolution by hour if duration <= 1 day (max 24 buckets)
-        if (duration / (24 * 3600)) <= 1:
-            return 'hour'
-        # Set resolution by day if duration <= 1 month (max 31 buckets)
-        if (duration / (24 * 3600 * 31)) <= 1:
-            return 'day'
-        # Set resolution by week if duration <= 6 months (max 24 buckets)
-        if (duration / (24 * 3600 * 31)) <= 6:
-            return 'week'
-        # Set resolution by month if duration <= 2 years (max 24 buckets)
-        if (duration / (24 * 3600 * 31 * 12)) <= 2:
-            return 'month'
-        return 'year'
-
-    def interval_to_format(interval):
-        if interval == 'hour':
-            return 'HH:mm'
-        if interval == 'day' or interval == 'week':
-            return 'yyyy-MM-dd'
-        if interval == 'month':
-            return 'yyyy-MM'
-        if interval == 'year':
-            return 'yyyy'
-        return 'yyyy-MM-dd HH:mm'
-
     duration = (params['lte'] - params['gte']) / 1000
     interval = set_histo_granularity(duration)
     fmt = interval_to_format(interval)
@@ -282,6 +286,39 @@ def events_histo(es, index, repository_fullname, params):
         data['aggregations']['agg1']['buckets'],
         data['aggregations']['avg_count']['value'] or 0,
     )
+
+
+def authors_histo(es, index, repository_fullname, params):
+    duration = (params['lte'] - params['gte']) / 1000
+    interval = set_histo_granularity(duration)
+    fmt = interval_to_format(interval)
+
+    body = {
+        "aggs": {
+            "agg1": {
+                "date_histogram": {
+                    "field": "created_at",
+                    "interval": interval,
+                    "format": fmt,
+                    "min_doc_count": 0,
+                    "extended_bounds": {"min": params['gte'], "max": params['lte']},
+                },
+                "aggs": {"authors": {"terms": {"field": "author", "size": 100000}}},
+            },
+            "avg_count": {"avg_bucket": {"buckets_path": "agg1>_count"}},
+        },
+        "size": 0,
+        "query": generate_filter(repository_fullname, params),
+    }
+    data = run_query(es, index, body)
+    res = data["aggregations"]["agg1"]["buckets"]
+    for bucket in res:
+        bucket['authors'] = [b['key'] for b in bucket['authors']['buckets']]
+        bucket['doc_count'] = len(bucket['authors'])
+    avg = sum([len(b['authors']) for b in res]) / len(res)
+    total = [b['authors'] for b in res]
+    total = len(set(chain(*total)))
+    return {'buckets': res, 'avg_authors': avg, 'total_authors': total}
 
 
 def _events_top(es, index, repository_fullname, field, params):

--- a/monocle/db/queries.py
+++ b/monocle/db/queries.py
@@ -58,6 +58,7 @@ public_queries = (
     "changes_lifecycle_stats",
     "changes_review_histos",
     "changes_review_stats",
+    "authors_histo_stats",
     "most_active_authors_stats",
     "most_reviewed_authors_stats",
     "last_changes",
@@ -714,6 +715,20 @@ def changes_lifecycle_stats(es, index, repository_fullname, params):
         events_count = count_events(es, index, repository_fullname, params)
         authors_count = count_authors(es, index, repository_fullname, params)
         ret[etype] = {'events_count': events_count, 'authors_count': authors_count}
+    return ret
+
+
+def authors_histo_stats(es, index, repository_fullname, params):
+    params = deepcopy(params)
+    ret = {}
+    etypes = (
+        'ChangeCreatedEvent',
+        "ChangeMergedEvent",
+        "ChangeCommentedEvent",
+    )
+    for etype in etypes:
+        params['etype'] = (etype,)
+        ret[etype] = authors_histo(es, index, repository_fullname, params)
     return ret
 
 

--- a/monocle/tests/unit/test_queries.py
+++ b/monocle/tests/unit/test_queries.py
@@ -164,6 +164,40 @@ class TestQueries(unittest.TestCase):
         if ddiff:
             raise DiffException(ddiff)
 
+    def test_authors_histo(self):
+        """
+        Test query: authors_histo
+        """
+        params = set_params({'gte': '2020-01-01', 'lte': '2020-01-02'})
+        ret = self.eldb.run_named_query('authors_histo', 'unit/repo1', params)
+        expected = {
+            'buckets': [
+                {
+                    'key_as_string': '2019-12-31',
+                    'key': 1577750400000,
+                    'doc_count': 0,
+                    'authors': [],
+                },
+                {
+                    'key_as_string': '2020-01-01',
+                    'key': 1577836800000,
+                    'doc_count': 2,
+                    'authors': ['jane', 'john'],
+                },
+                {
+                    'key_as_string': '2020-01-02',
+                    'key': 1577923200000,
+                    'doc_count': 1,
+                    'authors': ['jane'],
+                },
+            ],
+            'avg_authors': 1.0,
+            'total_authors': 2,
+        }
+        ddiff = DeepDiff(ret, expected)
+        if ddiff:
+            raise DiffException(ddiff)
+
     def test_events_top_authors(self):
         """
         Test query: events_top_authors

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -33,6 +33,7 @@ import {
 } from './components/user'
 import { CChangesLifeCycleStats } from './components/changes_lifecycle'
 import { CChangesReviewStats } from './components/changes_review'
+import { CAuthorsHistoStats } from './components/authors_histo'
 import {
   CNewContributorsStats,
   CMostActiveAuthorsStats,
@@ -98,6 +99,13 @@ class PeopleView extends React.Component {
   render () {
     return (
       <React.Fragment>
+        <Row><Col><p></p></Col></Row>
+        <Row>
+          <Col>
+            <CAuthorsHistoStats
+              index={this.props.match.params.index} />
+          </Col>
+        </Row>
         <Row><Col><p></p></Col></Row>
         <Row>
           <Col>

--- a/web/src/components/authors_histo.js
+++ b/web/src/components/authors_histo.js
@@ -1,0 +1,170 @@
+// Monocle.
+// Copyright (C) 2019-2020 Monocle authors
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import React from 'react'
+
+import { connect } from 'react-redux'
+
+import Row from 'react-bootstrap/Row'
+import Col from 'react-bootstrap/Col'
+import Card from 'react-bootstrap/Card'
+import ListGroup from 'react-bootstrap/ListGroup'
+import PropTypes from 'prop-types'
+import { withRouter } from 'react-router-dom'
+
+import { Line } from 'react-chartjs-2'
+
+import {
+  BaseQueryComponent,
+  LoadingBox,
+  ErrorBox,
+  mapDispatchToProps,
+  addMap
+} from './common'
+
+class AuthorsHisto extends React.Component {
+  prepareDataSet (histos) {
+    const createdColor = '135,255,149'
+    const reviewedColor = '153,102,102'
+    const commentedColor = '169,135,255'
+    const eventNameMapping = {
+      ChangeCreatedEvent: {
+        label: 'Changes authors',
+        pointBorderColor: `rgba(${createdColor},1)`,
+        pointBackgroundColor: '#fff',
+        backgroundColor: `rgba(${createdColor},0.4)`,
+        borderColor: `rgba(${createdColor},1)`
+      },
+      ChangeReviewedEvent: {
+        label: 'Reviews authors',
+        pointBorderColor: `rgba(${reviewedColor},1)`,
+        pointBackgroundColor: '#fff',
+        backgroundColor: `rgba(${reviewedColor},0.4)`,
+        borderColor: `rgba(${reviewedColor},1)`
+      },
+      ChangeCommentedEvent: {
+        label: 'Comments authors',
+        pointBorderColor: `rgba(${commentedColor},1)`,
+        pointBackgroundColor: '#fff',
+        backgroundColor: `rgba(${commentedColor},0.4)`,
+        borderColor: `rgba(${commentedColor},1)`
+      }
+    }
+
+    const metaData = Object.entries(eventNameMapping)
+    const data = {
+      labels: histos.ChangeCreatedEvent.buckets.map(x => x.key_as_string),
+      datasets: []
+    }
+    metaData.forEach(desc => {
+      data.datasets.push(
+        {
+          label: desc[1].label,
+          data: histos[desc[0]].buckets.map(x => x.doc_count),
+          lineTension: 0.5,
+          pointBorderColor: desc[1].pointBorderColor,
+          pointBackgroundColor: desc[1].pointBackgroundColor,
+          backgroundColor: desc[1].backgroundColor,
+          borderColor: desc[1].borderColor
+        }
+      )
+    })
+    return data
+  }
+
+  render () {
+    const data = this.prepareDataSet(this.props.data)
+    return (
+      <Row>
+        <Col>
+          <Card>
+            <Card.Body>
+              <Row>
+                <Col md={3}>
+                  <ListGroup>
+                    <ListGroup.Item>Change authors: { this.props.data.ChangeCreatedEvent.total_authors }</ListGroup.Item>
+                    <ListGroup.Item>Review authors: { this.props.data.ChangeReviewedEvent.total_authors }</ListGroup.Item>
+                    <ListGroup.Item>Comment authors: { this.props.data.ChangeCommentedEvent.total_authors }</ListGroup.Item>
+                  </ListGroup>
+                </Col>
+                <Col md={9}>
+                  <Line
+                    data={data}
+                    width={100}
+                    height={30}
+                  />
+                </Col>
+              </Row>
+            </Card.Body>
+          </Card>
+        </Col>
+      </Row>
+    )
+  }
+}
+
+AuthorsHisto.propTypes = {
+  data: PropTypes.shape({
+    ChangeCommentedEvent: PropTypes.object,
+    ChangeCreatedEvent: PropTypes.object,
+    ChangeReviewedEvent: PropTypes.object
+  })
+}
+
+class AuthorsHistoStats extends BaseQueryComponent {
+  constructor (props) {
+    super(props)
+    this.state.name = 'authors_histo_stats'
+    this.state.graph_type = 'authors_histo_stats'
+  }
+
+  render () {
+    if (!this.props.authors_histo_stats_loading) {
+      if (this.props.authors_histo_stats_error) {
+        return <ErrorBox
+          error={this.props.authors_histo_stats_error}
+        />
+      }
+      const data = this.props.authors_histo_stats_result
+      return (
+        <Row>
+          <Col>
+            <Card>
+              <Card.Header>
+                <Card.Title>Active authors</Card.Title>
+              </Card.Header>
+              <Card.Body>
+                <AuthorsHisto
+                  data={data}
+                />
+              </Card.Body>
+            </Card>
+          </Col>
+        </Row>
+      )
+    } else {
+      return <LoadingBox />
+    }
+  }
+}
+
+const mapStateToProps = state => addMap({}, state.QueryReducer, 'authors_histo_stats')
+
+const CAuthorsHistoStats = withRouter(connect(mapStateToProps, mapDispatchToProps)(AuthorsHistoStats))
+
+export {
+  CAuthorsHistoStats
+}

--- a/web/src/reducers/query.js
+++ b/web/src/reducers/query.js
@@ -26,6 +26,7 @@ const initialState = {}
 
 addStates(initialState, 'changes_lifecycle_stats')
 addStates(initialState, 'changes_review_stats')
+addStates(initialState, 'authors_histo_stats')
 addStates(initialState, 'most_active_authors_stats')
 addStates(initialState, 'approval_stats')
 addStates(initialState, 'most_reviewed_authors_stats')


### PR DESCRIPTION
This query with nested term aggregation will allow to build
histograms for events and changes based on authors.

Will be able to display the count of unique users by date
slots.

The query also compute the total uniq authors seens.