### PR TITLE
github crawler: do not fail on 'The additions count for this commit i…

### DIFF
--- a/monocle/github/graphql.py
+++ b/monocle/github/graphql.py
@@ -141,5 +141,18 @@ class GithubGraphQLQuery(object):
                 and 'timeout' in ret['errors'][0]['message']
             ):
                 raise RequestTimeout(ret['errors'][0]['message'])
+            if len(ret['errors']) >= 1:
+                if all(
+                    [
+                        error
+                        for error in ret['errors']
+                        if 'The additions count for this commit is unavailable'
+                        in error['message']
+                    ]
+                ):
+                    # This errors are not critical, PRs data are complete, w/o
+                    # the failing commit(s). So return the data to the caller and
+                    # move on.
+                    return ret
             raise RequestException("Errors in response: %s" % ret['errors'])
         return ret

--- a/monocle/github/pullrequest.py
+++ b/monocle/github/pullrequest.py
@@ -449,6 +449,8 @@ class PRsFetcher(object):
             # it does not provide more data than the current list of commits
             # of the pull request
             for commit in pr['commits']['edges']:
+                if not commit['node']:
+                    continue
                 _commit = commit['node']['commit']
                 obj = {
                     'type': 'ChangeCommitPushedEvent',
@@ -464,6 +466,8 @@ class PRsFetcher(object):
                 objects.append(obj)
             # Now attach a commits list to the change
             for commit in pr['commits']['edges']:
+                if not commit['node']:
+                    continue
                 _commit = commit['node']['commit']
                 obj = {
                     'sha': _commit['oid'],


### PR DESCRIPTION
…s unavailable'

This error may happen. I saw it with that PR:
pullrequest.py  --token XXX --org elastic --repository built-docs --id 3

It seems the returned data is complete but w/o the commit (that miss that
'additions' field). So instead of managing that like an error, we
consider it as not fatal and return the data to the caller.

The crawler won't fail on that kind of error.

Fix #222