### PR TITLE
[web] fix wrong backend query on the change page (gte missing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 ### Fixed
 
+[web] fix wrong backend query on the change page (gte missing)
+
 
 ## [0.5] - 2020-06-04
 

--- a/web/src/components/common.js
+++ b/web/src/components/common.js
@@ -272,6 +272,7 @@ class BaseQueryComponent extends React.Component {
         graph_type: this.state.graph_type,
         repository: params.get('repository') || '.*',
         branch: params.get('branch'),
+        gte: params.get('gte'),
         changeIds: this.props.changeIds
       })
     } else {


### PR DESCRIPTION
The change fixes a situation where the default gte is used (now-3months)
even if an older gte is specified. So a change appaering in changes listing
could not be clicked as the backend will return empty data.