### PR TITLE
[api] fix change_lifecycle_stats return null values when authors is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-[web] reworked the look and feel of changes tables for a better readability
-[web] set bootstrap table with size=sm for a better look and feel
+- [web] reworked the look and feel of changes tables for a better readability
+- [web] set bootstrap table with size=sm for a better look and feel
 
 ### Removed
 ### Fixed
+
+- [api] fix change_lifecycle_stats return null values when authors is set
 
 [web] fix wrong backend query on the change page (gte missing)
 

--- a/monocle/db/queries.py
+++ b/monocle/db/queries.py
@@ -22,7 +22,6 @@ from datetime import datetime
 from itertools import groupby
 from itertools import chain
 from monocle.utils import dbdate_to_datetime
-from monocle.utils import float_trunc
 from monocle.utils import enhance_changes
 from monocle.utils import Detector
 
@@ -514,7 +513,6 @@ def count_abandoned_changes(es, index, repository_fullname, params):
 
 def changes_closed_ratios(es, index, repository_fullname, params):
     params = deepcopy(params)
-    switch_to_on_authors(params)
     etypes = (
         'ChangeCreatedEvent',
         "ChangeCommitPushedEvent",
@@ -691,7 +689,6 @@ def changes_lifecycle_histos(es, index, repository_fullname, params):
 
 def changes_lifecycle_stats(es, index, repository_fullname, params):
     params = deepcopy(params)
-    switch_to_on_authors(params)
     ret = {}
     ret['ratios'] = changes_closed_ratios(es, index, repository_fullname, params)
     ret['histos'] = changes_lifecycle_histos(es, index, repository_fullname, params)
@@ -703,14 +700,10 @@ def changes_lifecycle_stats(es, index, repository_fullname, params):
     ret['abandoned'] = count_abandoned_changes(es, index, repository_fullname, params)
     etypes = (
         'ChangeCreatedEvent',
-        "ChangeMergedEvent",
-        "ChangeAbandonedEvent",
         "ChangeCommitPushedEvent",
         "ChangeCommitForcePushedEvent",
     )
-    ret['avgs'] = {}
     for etype in etypes:
-        ret['avgs'][etype] = float_trunc(ret['histos'][etype][-1])
         params['etype'] = (etype,)
         events_count = count_events(es, index, repository_fullname, params)
         authors_count = count_authors(es, index, repository_fullname, params)

--- a/monocle/tests/unit/test_queries.py
+++ b/monocle/tests/unit/test_queries.py
@@ -323,3 +323,318 @@ class TestQueries(unittest.TestCase):
         params = set_params({})
         ret = self.eldb.run_named_query('last_changes', 'unit/repo[12]', params)
         self.assertEqual(ret['total'], 4, ret)
+
+    def test_changes_lifecycle_stats(self):
+        """
+        Test changes_lifecycle_stats query
+        """
+        params = set_params({'gte': '2020-01-01', 'lte': '2020-01-03'})
+        ret = self.eldb.run_named_query('changes_lifecycle_stats', '.*', params)
+        expected = {
+            'ChangeCommitForcePushedEvent': {'authors_count': 0, 'events_count': 0},
+            'ChangeCommitPushedEvent': {'authors_count': 1, 'events_count': 1},
+            'ChangeCreatedEvent': {'authors_count': 2, 'events_count': 2},
+            'abandoned': 0,
+            'commits': 1.0,
+            'duration': 86400.0,
+            'histos': {
+                'ChangeAbandonedEvent': (
+                    [
+                        {
+                            'doc_count': 0,
+                            'key': 1577750400000,
+                            'key_as_string': '2019-12-31',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1577836800000,
+                            'key_as_string': '2020-01-01',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1577923200000,
+                            'key_as_string': '2020-01-02',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1578009600000,
+                            'key_as_string': '2020-01-03',
+                        },
+                    ],
+                    0,
+                ),
+                'ChangeCommitForcePushedEvent': (
+                    [
+                        {
+                            'doc_count': 0,
+                            'key': 1577750400000,
+                            'key_as_string': '2019-12-31',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1577836800000,
+                            'key_as_string': '2020-01-01',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1577923200000,
+                            'key_as_string': '2020-01-02',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1578009600000,
+                            'key_as_string': '2020-01-03',
+                        },
+                    ],
+                    0,
+                ),
+                'ChangeCommitPushedEvent': (
+                    [
+                        {
+                            'doc_count': 0,
+                            'key': 1577750400000,
+                            'key_as_string': '2019-12-31',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1577836800000,
+                            'key_as_string': '2020-01-01',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1577923200000,
+                            'key_as_string': '2020-01-02',
+                        },
+                        {
+                            'doc_count': 1,
+                            'key': 1578009600000,
+                            'key_as_string': '2020-01-03',
+                        },
+                    ],
+                    0.25,
+                ),
+                'ChangeCreatedEvent': (
+                    [
+                        {
+                            'doc_count': 0,
+                            'key': 1577750400000,
+                            'key_as_string': '2019-12-31',
+                        },
+                        {
+                            'doc_count': 1,
+                            'key': 1577836800000,
+                            'key_as_string': '2020-01-01',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1577923200000,
+                            'key_as_string': '2020-01-02',
+                        },
+                        {
+                            'doc_count': 1,
+                            'key': 1578009600000,
+                            'key_as_string': '2020-01-03',
+                        },
+                    ],
+                    0.5,
+                ),
+                'ChangeMergedEvent': (
+                    [
+                        {
+                            'doc_count': 0,
+                            'key': 1577750400000,
+                            'key_as_string': '2019-12-31',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1577836800000,
+                            'key_as_string': '2020-01-01',
+                        },
+                        {
+                            'doc_count': 1,
+                            'key': 1577923200000,
+                            'key_as_string': '2020-01-02',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1578009600000,
+                            'key_as_string': '2020-01-03',
+                        },
+                    ],
+                    0.25,
+                ),
+            },
+            'merged': 1,
+            'opened': 1,
+            'ratios': {
+                'abandoned/created': 0.0,
+                'iterations/created': 1.5,
+                'merged/created': 50.0,
+            },
+            'tests': 50.0,
+        }
+        ddiff = DeepDiff(ret, expected)
+        if ddiff:
+            raise DiffException(ddiff)
+
+        params = set_params(
+            {'gte': '2020-01-01', 'lte': '2020-01-03', 'authors': 'john,jane'}
+        )
+        ret = self.eldb.run_named_query('changes_lifecycle_stats', '.*', params)
+        ddiff = DeepDiff(ret, expected)
+        if ddiff:
+            raise DiffException(ddiff)
+
+        params = set_params(
+            {'gte': '2020-01-01', 'lte': '2020-01-03', 'authors': 'john'}
+        )
+        ret = self.eldb.run_named_query('changes_lifecycle_stats', '.*', params)
+        from pprint import pprint
+
+        pprint(ret)
+        expected = {
+            'ChangeCommitForcePushedEvent': {'authors_count': 0, 'events_count': 0},
+            'ChangeCommitPushedEvent': {'authors_count': 0, 'events_count': 0},
+            'ChangeCreatedEvent': {'authors_count': 1, 'events_count': 1},
+            'abandoned': 0,
+            'commits': 1.0,
+            'duration': 86400.0,
+            'histos': {
+                'ChangeAbandonedEvent': (
+                    [
+                        {
+                            'doc_count': 0,
+                            'key': 1577750400000,
+                            'key_as_string': '2019-12-31',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1577836800000,
+                            'key_as_string': '2020-01-01',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1577923200000,
+                            'key_as_string': '2020-01-02',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1578009600000,
+                            'key_as_string': '2020-01-03',
+                        },
+                    ],
+                    0,
+                ),
+                'ChangeCommitForcePushedEvent': (
+                    [
+                        {
+                            'doc_count': 0,
+                            'key': 1577750400000,
+                            'key_as_string': '2019-12-31',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1577836800000,
+                            'key_as_string': '2020-01-01',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1577923200000,
+                            'key_as_string': '2020-01-02',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1578009600000,
+                            'key_as_string': '2020-01-03',
+                        },
+                    ],
+                    0,
+                ),
+                'ChangeCommitPushedEvent': (
+                    [
+                        {
+                            'doc_count': 0,
+                            'key': 1577750400000,
+                            'key_as_string': '2019-12-31',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1577836800000,
+                            'key_as_string': '2020-01-01',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1577923200000,
+                            'key_as_string': '2020-01-02',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1578009600000,
+                            'key_as_string': '2020-01-03',
+                        },
+                    ],
+                    0,
+                ),
+                'ChangeCreatedEvent': (
+                    [
+                        {
+                            'doc_count': 0,
+                            'key': 1577750400000,
+                            'key_as_string': '2019-12-31',
+                        },
+                        {
+                            'doc_count': 1,
+                            'key': 1577836800000,
+                            'key_as_string': '2020-01-01',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1577923200000,
+                            'key_as_string': '2020-01-02',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1578009600000,
+                            'key_as_string': '2020-01-03',
+                        },
+                    ],
+                    0.25,
+                ),
+                'ChangeMergedEvent': (
+                    [
+                        {
+                            'doc_count': 0,
+                            'key': 1577750400000,
+                            'key_as_string': '2019-12-31',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1577836800000,
+                            'key_as_string': '2020-01-01',
+                        },
+                        {
+                            'doc_count': 1,
+                            'key': 1577923200000,
+                            'key_as_string': '2020-01-02',
+                        },
+                        {
+                            'doc_count': 0,
+                            'key': 1578009600000,
+                            'key_as_string': '2020-01-03',
+                        },
+                    ],
+                    0.25,
+                ),
+            },
+            'merged': 1,
+            'opened': 0,
+            'ratios': {
+                'abandoned/created': 0.0,
+                'iterations/created': 1.0,
+                'merged/created': 100.0,
+            },
+            'tests': 100.0,
+        }
+        ddiff = DeepDiff(ret, expected)
+        if ddiff:
+            raise DiffException(ddiff)


### PR DESCRIPTION
This change fixes the query when called with a authors param set. The result
was 0 for opened/abandoned/merged changes (ratio too).

The use of switch_to_on_authors was incorrect since we changed the computation
method of opened/abandoned/merged changes count (no longer use event objects,
but change objects directly).

This change also removes un-used (by the Monocle UI) data from query computation.