### PR TITLE
[api] ensure most_active_authors_stats display top authors by merged …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 ### Fixed
 
+- [api] ensure most_active_authors_stats display top authors by merged change.
 - [api] fix change_lifecycle_stats return null values when authors is set
 
 [web] fix wrong backend query on the change page (gte missing)

--- a/monocle/db/queries.py
+++ b/monocle/db/queries.py
@@ -760,8 +760,8 @@ def most_active_authors_stats(es, index, repository_fullname, params):
     for etype in ("ChangeCreatedEvent", "ChangeReviewedEvent", "ChangeCommentedEvent"):
         params['etype'] = (etype,)
         ret[etype] = events_top_authors(es, index, repository_fullname, params)
-    switch_to_on_authors(params)
-    params['etype'] = ("ChangeMergedEvent",)
+    params['etype'] = ("Change",)
+    params['state'] = 'MERGED'
     ret["ChangeMergedEvent"] = events_top_authors(
         es, index, repository_fullname, params
     )

--- a/monocle/tests/unit/test_queries.py
+++ b/monocle/tests/unit/test_queries.py
@@ -638,3 +638,97 @@ class TestQueries(unittest.TestCase):
         ddiff = DeepDiff(ret, expected)
         if ddiff:
             raise DiffException(ddiff)
+
+    def test_most_active_authors_stats(self):
+        """
+        Test query: most_active_authors_stats
+        """
+        params = set_params({})
+        ret = self.eldb.run_named_query('most_active_authors_stats', '.*', params)
+        expected = {
+            'ChangeCommentedEvent': {
+                'count_avg': 1,
+                'count_median': 1.0,
+                'items': [
+                    {'doc_count': 1, 'key': 'jane'},
+                    {'doc_count': 1, 'key': 'steve'},
+                ],
+                'total': 2,
+                'total_hits': 2,
+            },
+            'ChangeCreatedEvent': {
+                'count_avg': 1.3333333333333333,
+                'count_median': 1,
+                'items': [
+                    {'doc_count': 2, 'key': 'jane'},
+                    {'doc_count': 1, 'key': 'john'},
+                    {'doc_count': 1, 'key': 'steve'},
+                ],
+                'total': 3,
+                'total_hits': 4,
+            },
+            'ChangeMergedEvent': {
+                'count_avg': 1,
+                'count_median': 1,
+                'items': [
+                    {'doc_count': 1, 'key': 'jane'},
+                    {'doc_count': 1, 'key': 'john'},
+                    {'doc_count': 1, 'key': 'steve'},
+                ],
+                'total': 3,
+                'total_hits': 3,
+            },
+            'ChangeReviewedEvent': {
+                'count_avg': 1,
+                'count_median': 1.0,
+                'items': [
+                    {'doc_count': 1, 'key': 'john'},
+                    {'doc_count': 1, 'key': 'steve'},
+                ],
+                'total': 2,
+                'total_hits': 2,
+            },
+        }
+        ddiff = DeepDiff(ret, expected)
+        if ddiff:
+            raise DiffException(ddiff)
+
+        params = set_params({'authors': 'jane'})
+        ret = self.eldb.run_named_query('most_active_authors_stats', '.*', params)
+        from pprint import pprint
+
+        pprint(ret)
+        expected = {
+            'ChangeCommentedEvent': {
+                'count_avg': 1,
+                'count_median': 1,
+                'items': [{'doc_count': 1, 'key': 'jane'}],
+                'total': 1,
+                'total_hits': 1,
+            },
+            'ChangeCreatedEvent': {
+                'count_avg': 2,
+                'count_median': 2,
+                'items': [{'doc_count': 2, 'key': 'jane'}],
+                'total': 1,
+                'total_hits': 2,
+            },
+            'ChangeMergedEvent': {
+                'count_avg': 1,
+                'count_median': 1,
+                'items': [{'doc_count': 1, 'key': 'jane'}],
+                'total': 1,
+                'total_hits': 1,
+            },
+            'ChangeReviewedEvent': {
+                'count_avg': 0,
+                'count_median': 0,
+                'items': [],
+                'total': 0,
+                'total_hits': 0,
+            },
+        }
+
+        ddiff = DeepDiff(ret, expected)
+        if ddiff:
+            raise DiffException(ddiff)


### PR DESCRIPTION
…change

Currently the query returns the top merge events' authors if no
authors is specified in the authors filter. I think this should
return whether authors filter is set or not the top change merged's
authors.

The current behavior is also weird when a user look at the people
page/Most reviewed authors stats he see sometime a higher walue
in 'By Merged Changes' compared to "By Created Changes' for a
given author.

Furthermore gerrit 2.X does not return change submitter then the
ChangeMergedEvent own a author attribute to None. This makes
the 'By Merged Changes' list empty.

This fix this behavior by using the Change object directly to compute
the top authors of change merged in the most_active_authors_stats query.
This change also brings a unittest for this query.