### PR TITLE
[web]: pie charts: extracts legend outside the graph itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 ### Fixed
 
+- [web] pie charts invisible when legend is too large.
+
 ## [0.6] - 2020-08-20
 
 ### Added

--- a/monocle/config.py
+++ b/monocle/config.py
@@ -166,7 +166,9 @@ tenants:
 
 def validate(data, schema):
     schema_validate(
-        instance=data, schema=schema, format_checker=draft7_format_checker,
+        instance=data,
+        schema=schema,
+        format_checker=draft7_format_checker,
     )
 
 

--- a/monocle/github/application.py
+++ b/monocle/github/application.py
@@ -100,12 +100,16 @@ def get_installation_key(install: Installation) -> str:
     return token
 
 
-def get_installation_headers(install: Installation,) -> Dict[str, str]:
+def get_installation_headers(
+    install: Installation,
+) -> Dict[str, str]:
     token = get_installation_key(install)
     return {'Accept': PREVIEW_JSON_ACCEPT, 'Authorization': 'token %s' % token}
 
 
-def get_repos_of_installation(install: Installation,) -> List[str]:
+def get_repos_of_installation(
+    install: Installation,
+) -> List[str]:
     url = install.repositories_url
     headers = get_installation_headers(install)
     projects = []

--- a/monocle/github/pullrequest.py
+++ b/monocle/github/pullrequest.py
@@ -584,7 +584,8 @@ if __name__ == '__main__':
     )
     parser.add_argument('--id', help='The pull request id')
     parser.add_argument(
-        '--output-dir', help='Store the dump in this directory',
+        '--output-dir',
+        help='Store the dump in this directory',
     )
 
     args = parser.parse_args()

--- a/monocle/main.py
+++ b/monocle/main.py
@@ -57,10 +57,13 @@ def main():
 
     parser_dbmanage = subparsers.add_parser('dbmanage', help='Database manager')
     parser_dbmanage.add_argument(
-        '--delete-repository', help='Delete events related to a repository (regexp)',
+        '--delete-repository',
+        help='Delete events related to a repository (regexp)',
     )
     parser_dbmanage.add_argument(
-        '--delete-index', help='Delete the index', action='store_true',
+        '--delete-index',
+        help='Delete the index',
+        action='store_true',
     )
     parser_dbmanage.add_argument(
         '--index', help='The Elastisearch index name', required=True


### PR DESCRIPTION
react-charjs2 does not handle well the pie legend that can be
too large and makes the engine decrease the pie size. Sometime
the graph is invisible.

This change lets the full size to the pie and compute + display
the legend ouside the chart.