### PR TITLE
Update git url from morruci to change-metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The process below describes how to index changes from a GitHub repository, a ful
 ### Clone and create the needed directories
 
 ```Shell
-$ git clone https://github.com/morucci/monocle.git
+$ git clone https://github.com/change-metrics/monocle.git
 $ cd monocle
 $ mkdir data etc dump
 $ ln -s docker-compose.yml.img docker-compose.yml


### PR DESCRIPTION
I suspect this is a remnant from a rename or migrating the repository to a organisation. It's still technically correct (in that it works), but perhaps best to change it for full clarity.

Feel free to disregard and close the PR if you disagree or think it's too small a change. :)