### PR TITLE
GHA: switch for olegtarasov/get-tag@v2.1

### DIFF
--- a/.github/workflows/publish-tag.yaml
+++ b/.github/workflows/publish-tag.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - uses: olegtarasov/get-tag@v2
+      - uses: olegtarasov/get-tag@v2.1
         id: tagName
 
       - name: Display tag name


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/