### PR TITLE
Added support for REMOTE_USER header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [master]
 
 ### Added
+
+- [web] Support for REMOTE_USER header to enable external authentication system
+
 ### Changed
 ### Removed
 ### Fixed
@@ -211,7 +214,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- [api,backend] renamed projects.yaml to config.yaml. projects key replaced by tenants key. [BREAKING] 
+- [api,backend] renamed projects.yaml to config.yaml. projects key replaced by tenants key. [BREAKING]
 - [db] add target_branch and branch to events. Need to re-index to be able to use these fields. [BREAKING]
 - [db] prefix the names of indices by `monocle.changes.`. Need to recreate the indexes or create an alias if you want to keep them. [BREAKING]
 

--- a/README.md
+++ b/README.md
@@ -305,6 +305,17 @@ A new field `self_merged` has been added. Previously indexed changes can be upda
 docker-compose run --no-deps crawler /usr/local/bin/monocle --elastic-conn elastic:9200 dbmanage --index <index-name> --run-migrate self-merge
 ```
 
+## Using external authentication system
+
+Monocle is supporting the "REMOTE_USER" header, which is mostly used
+by sign-on solutions. When Web server takes care of authentitaction,
+it set a "REMOTE_USER" environment variable, which can be used by Monocle.
+To check that, you are able to run simple curl command:
+
+```Shell
+curl --header "REMOTE_USER: Daniel" -XGET http://localhost:9876/api/0/whoami
+```
+
 ## Contributing
 
 Follow [our contributing guide](CONTRIBUTING.md).

--- a/monocle/webapp.py
+++ b/monocle/webapp.py
@@ -117,7 +117,7 @@ def authorize():
 def whoami():
     if not os.getenv("CLIENT_ID"):
         return "Authentication not configured", 503
-    username = session.get("username")
+    username = session.get("username") or request.headers.get("Remote-User")
     return jsonify(username)
 
 
@@ -127,7 +127,7 @@ def query(name):
         abort(make_response(jsonify(errors=["No index provided"]), 404))
     index = request.args.get("index")
     if not config.is_public_index(indexes_acl, index):
-        user = session.get("username")
+        user = session.get("username") or request.headers.get("Remote-User")
         if user:
             if user not in config.get_authorized_users(indexes_acl, index):
                 return "Unauthorized to access index %s" % index, 403


### PR DESCRIPTION
Some application like cauth is setting the REMOTE_USER
header, so additional authorization is not required.