### PR TITLE
Added project_definition support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   across code review systems.
 - [dbmanage] Added update-idents option.
 - [api,web,crawler] - added secure communication (SSL) and user authentication with Elasticsearch
+- [api] Added 'projects' API endpoint that is listening project definitions from config file
 
 ### Changed
 ### Removed

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Monocle is able to index changes from multiple code review systems. A contributo
 might get different identities across code review systems. Thus Monocle provides
 a configuration section to define aliases for contributors.
 
-Let say a Monocle index is configured to fetch changes from github.com and review.opendev.org (Gerrit) and we would like that John's metrics are merged under the `John Doe` identity. 
+Let say a Monocle index is configured to fetch changes from github.com and review.opendev.org (Gerrit) and we would like that John's metrics are merged under the `John Doe` identity.
 
 ```YAML
 tenants:

--- a/monocle/utils.py
+++ b/monocle/utils.py
@@ -208,6 +208,7 @@ def set_params(input: Namespace) -> Dict:
     params["has_issue_tracker_links"] = getter("has_issue_tracker_links", None)
     params["change_ids"] = getter("change_ids", None)
     params["target_branch"] = getter("target_branch", None)
+    params["project_definition"] = getter("project_definition", None)
     for sp in (
         "change_ids",
         "exclude_authors",


### PR DESCRIPTION
This commit provides project_definition support. It means
that you are able to define project in your index definition,
and monocle will return only informations related to
repositories-regex [1]. For example:

tenants:
  - index: openstack
    crawler:
      loop_delay: 600
      gerrit_repositories:
        - name: "^openstack/.*"
          updated_since: "2021-01-01"
          base_url: https://review.opendev.org/
    projects:
      - name: infra
        repositories-regex: "opendev/system-config|openstack/disskimage-builder"

The infra project definition returns statistics related only for those
repositories that are in repositories-regex.

[1] https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html