### PR TITLE
Changing Tooltip module name

### DIFF
--- a/web/src/components/Indices.res
+++ b/web/src/components/Indices.res
@@ -8,9 +8,9 @@ open Prelude
 module Indice = {
   @react.component
   let make = (~name) =>
-    <Tooltip position=#Bottom content={"Click to get the metric"}>
+    <Tooltip2 position=#Bottom content={"Click to get the metric"}>
       <a href="" onClick={_ => RescriptReactRouter.push(name)}> {name->React.string} </a>
-    </Tooltip>
+    </Tooltip2>
 
   let card: string => React.element = name => <MSimpleCard> {make({"name": name})} </MSimpleCard>
 }

--- a/web/src/components/Prelude.res
+++ b/web/src/components/Prelude.res
@@ -8,7 +8,7 @@
 include Patternfly
 include Layout
 
-module Tooltip = {
+module Tooltip2 = {
   @react.component @module("@patternfly/react-core")
   external make: (
     ~children: 'children,


### PR DESCRIPTION
The rescript may raise an error on recompiling the code.
This commit is changing that.