### PR TITLE
[doc] Add query language proposal

### DIFF
--- a/doc/adr/0011-search-query-language.md
+++ b/doc/adr/0011-search-query-language.md
@@ -1,6 +1,9 @@
 # 11. Search query language
 
+* Status: accepted
 * Date: 2021-05-19
+* Deciders: Fabien Boucher
+* Issue: https://github.com/change-metrics/monocle/issues/372
 
 ## Context and Problem Statement
 

--- a/doc/adr/0011-search-query-language.md
+++ b/doc/adr/0011-search-query-language.md
@@ -1,0 +1,64 @@
+# 11. Search query language
+
+* Date: 2021-05-19
+
+## Context and Problem Statement
+
+To build custom dashboards we need to define queries that are too complex for the existing filter box form.
+We would like to use flexible search expressions based on a proper query language.
+
+## Considered Options
+
+* GitHub Search Syntax
+* Kibana Query Language
+* Luqum
+* Monocle Query Language
+
+## Decision Outcome
+
+Chosen option: "Monocle Query Language", because it comes out best (see below).
+
+### Positive Consequences
+
+- We improve the user experience by replacing the clunky filter box with a simpler search bar.
+- We create a re-usable component.
+
+### Negative Consequences
+
+- We need to maintain a language toolchain.
+
+## Pros and Cons of the Options
+
+### GitHub Search Syntax
+
+https://docs.github.com/en/github/searching-for-information-on-github/getting-started-with-searching-on-github/understanding-the-search-syntax
+
+* Good, because many parser already exists.
+* Bad, because it does not support boolean operators.
+
+### Kibana Query Language
+
+The Kibana Query Language (KQL) is a simple syntax for filtering Elasticsearch data using free text search or field-based search:
+https://www.elastic.co/guide/en/kibana/current/kuery-query.html
+
+* Good, because it is standard in the elastic stack.
+* Bad, because it is complex to integrate in the existing code base.
+
+### Luqum
+
+Luqum stands for LUcene QUery Manipolator: https://luqum.readthedocs.io
+
+* Good, because it is simple to use.
+* Bad, because it is not supported on the client side.
+* Bad, because it supports complex syntax.
+
+### Monocle Query Language
+
+We implement our own query language:
+
+- As a subset of KQL, e.g. without generic nested field.
+  Instead of `change.reviewer.{ author: foo }` we provide a flat `change_reviewer_author: foo` field.
+- Server side validation and es query transformer, e.g. to expand group name fields.
+
+* Good, because it fits our domain.
+* Bad, because it needs to be implemented.

--- a/doc/query-language.md
+++ b/doc/query-language.md
@@ -59,6 +59,7 @@ le = "<="
 
 ; search operator
 order-by = "order by" / "ORDER BY"
+order-by-sort = "asc" / "ASC" / "desc" / "DESC"
 limit = "limit" / "LIMIT"
 
 expression =
@@ -75,6 +76,7 @@ expression =
     / field whsp le whsp value
 
     ; search operator
+    / expression whsp1 order-by whsp1 field whsp1 order-by-sort
     / expression whsp1 order-by whsp1 field
     / expression whsp1 limit whsp1 1*digit
 

--- a/doc/query-language.md
+++ b/doc/query-language.md
@@ -1,0 +1,221 @@
+Monocle Query Language
+======================
+
+This document introduces the Monocle Query Language standard.
+
+Example queries:
+
+- `state:open and review_count:0`
+- `(repo : openstack/nova or repo: openstack/neutron) and user_group:qa and updated_at > 2020 order by score`
+
+
+# Backus–Naur form
+
+Machine readable specification of the grammar:
+
+```abnf
+; ABNF syntax based on RFC 5234
+;
+; notes:
+; - `/`       means OR
+; - `*`       repeats zero or more
+; - `1*`      repeats one or more
+; - `%xXX-YY` means byte range between 0xXX and 0xYY
+
+
+; whitespace
+whitespace-chunk = " " / "\t"
+whsp = *whitespace-chunk
+
+; nonempty whitespace
+whsp1 = 1*whitespace-chunk
+
+; Uppercase or lowercase ASCII letter
+ascii = %x41-5A / %x61-7A
+; ASCII digit
+digit = %x30-39
+
+; ASCII letter or "_"
+label-char = ascii / "_"
+
+; label-char or ASCII digit or "-"
+value-char = label-char / digit / "-" / "/"
+
+; Field and value
+field = 1*label-char
+value = 1*value-char
+
+; boolean operator
+and = "and" / "AND" / "∧" / "&&"
+or  = "or"  / "OR"  / "∨" / "||"
+not = "not" / "NOT" / "¬" / "!"
+
+; field operator
+eq = ":" / "=" / "=="
+gt = ">"
+ge = ">="
+lt = "<"
+le = "<="
+
+; search operator
+order-by = "order by" / "ORDER BY"
+limit = "limit" / "LIMIT"
+
+expression =
+    ; boolean operator
+      expression whsp1 and whsp1 expression
+    / expression whsp1 or whsp1 expression
+    / not whsp1 expression
+
+    ; field operator
+    / field whsp eq whsp value
+    / field whsp gt whsp value
+    / field whsp ge whsp value
+    / field whsp lt whsp value
+    / field whsp le whsp value
+
+    ; search operator
+    / expression whsp1 order-by whsp1 field
+    / expression whsp1 limit whsp1 1*digit
+
+    ; priority operator
+    / "(" whsp expression whsp ")"
+```
+
+# Expr data type
+
+The language is parsed into a AST composed of a single recursive Expr data type defined as follow:
+
+```haskell
+type Field = Text
+type Value = Text
+
+data Expr =
+  -- Bool operator
+    AndExpr Expr Expr
+  | OrExpr  Expr Expr
+  | NotExpr Expr
+  -- Field operator
+  | EqExpr   Field Value
+  | GtExpr   Field Value
+  | LtExpr   Field Value
+  | GtEqExpr Field Value
+  | LtEqExpr Field Value
+  -- Search operator
+  | OrderByExpr Field Expr
+  | LimitExpr   Int   Expr
+```
+
+Thus, the example queries are represented like this:
+
+```haskell
+example_query1 :: Expr
+example_query1 =
+  OrExpr
+    (EqExpr "state" "open")
+    (EqExpr "review_count" "0")
+
+example_query2 :: Expr
+example_query2 =
+  OrderByExpr "score"
+    (AndExpr
+      (OrExpr
+        (EqExpr "repo" "openstack/nova")
+        (EqExpr "repo" "openstack/neutron"))
+      (AndExpr
+        (EqExpr "user_group" "qa")
+        (GtExpr "updated_at" "2020")))
+```
+
+# Type check rules
+
+The expression is validated using field specifications defined as follow:
+
+```haskell
+data FieldType = FieldDate | FieldNumber | FieldText
+
+fields :: [(FieldType, [Field])]
+fields = [
+    (FieldDate,   ["updated_at", "created_at"])
+  , (FieldNumber, ["pm_score", "review_count", "comment_count"])
+  , (FieldText,   ["repo",    "repo_regexp"])
+  , (FieldText,   ["user",    "user_regexp",    "user_group"])
+  , (FieldText,   ["project", "project_regexp", "project_group"])
+]
+```
+
+- DateField must follow one of these syntaxs: YYYY, YYYY-MM, YYYY-MM-DD
+- Greater and Lower field operator must only be used with date or number fields.
+- Search operator (OrderBy and Limit) may only appear once at the outer layer.
+
+# Compilation to ElasticeSearch query
+
+The expression may be transformed with such rules:
+
+- `NotExpr (NotExpr e)`  -> `e`
+- `NotExpr (EqExpr f v)` -> `f != v`
+- `NotExpr (GtExpr f v)` -> `f <= v`
+- `NotExpr (LtExpr f v)` -> `f >= v`
+- `AndExpr e1 (AndExpr e2 e3)` -> `e1 && e2 && e3`
+- `OrExpr (EqExpr f v1) (EqExpr f v2)` -> `f in [v1, v2]`
+
+The operator are converted to ES query:
+
+- And -> bool.must
+- Or  -> bool.should
+- Eq  -> regexp.{field}.value  (when field type is regexp)
+- Eq  -> term.{field}
+- Gt  -> range.{field}.gte
+- Lt  -> range.{field}.lte
+
+The field name and values are transformed accordingly by the API based on the internal document schema.
+For example, the query field `repo_regexp` is converted to the document field `repository_fullname`.
+
+The example query is converted to:
+
+```json
+{
+  "bool": {
+    "must": [
+      {
+        "bool": {
+          "should": [
+            {
+              "term": {
+                "repository_fullname": "openstack/nova"
+              }
+            },
+            {
+              "term": {
+                "repository_fullname": "openstack/neutron"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "terms": {
+          "author": ["qa-user-1", "qa-user-2"]
+        }
+      },
+      {
+        "range": {
+          "update_at": {
+            "gte": "2020"
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+# Extension
+
+The language may be extended with the following features:
+
+- `field in [x, xs..]`
+- quoted value, e.g.: `user:"Foo Bar"`
+- inline range, e.g.: `count:0..10`
+- relative date, e.g.: `now-3weeks`
+- unicode value

--- a/haskell/app/Search.hs
+++ b/haskell/app/Search.hs
@@ -1,0 +1,7 @@
+-- |
+module Main where
+
+import Monocle.Search.CLI (searchMain)
+
+main :: IO ()
+main = searchMain

--- a/haskell/cabal.project
+++ b/haskell/cabal.project
@@ -1,0 +1,7 @@
+source-repository-package
+  type: git
+  location: https://github.com/bitemyapp/bloodhound
+  tag: 4775ebb759fe1b7cb5f880e4a41044b2363d98af
+  -- Pull in version bump that needs a new release
+
+packages: .

--- a/haskell/monocle.cabal
+++ b/haskell/monocle.cabal
@@ -31,8 +31,7 @@ common common-options
   if impl(ghc >= 8.2)
     ghc-options:       -fhide-source-paths
   if impl(ghc >= 8.4)
-    ghc-options:       -Wmissing-export-lists
-                       -Wpartial-fields
+    ghc-options:       -Wpartial-fields
   if impl(ghc >= 8.10)
     ghc-options:       -Wunused-packages
 
@@ -49,6 +48,8 @@ library
                      , http-client-tls            < 0.4
                      , proto3-suite               >= 0.4.2
                      , proto3-wire                >= 1.2.0
+                     , megaparsec                 < 10
+                     , parser-combinators         < 1.3
                      , relude                     > 1.0.0.0
                      , retry                      < 0.9
                      , streaming                  < 0.3
@@ -67,6 +68,9 @@ library
                      , Monocle.Client
                      , Monocle.Config
                      , Monocle.Search
+                     , Monocle.Search.Lexer
+                     , Monocle.Search.Syntax
+                     , Monocle.Search.Parser
                      , Monocle.TaskData
                      , Monocle.WebApi
                      , Monocle.Worker

--- a/haskell/monocle.cabal
+++ b/haskell/monocle.cabal
@@ -64,18 +64,19 @@ library
                      , warp                       ^>= 3.3.15
                      , yaml                       ^>= 0.11
   hs-source-dirs:      src
-  exposed-modules:     Monocle.Api.Config
+  exposed-modules:     Monocle.Api.CLI
+                     , Monocle.Api.Config
                      , Monocle.Api.HTTP
-                     , Monocle.Api.CLI
                      , Monocle.Client
                      , Monocle.Config
                      , Monocle.Search
-                     , Monocle.Search.Change
                      , Monocle.Search.CLI
+                     , Monocle.Search.Change
                      , Monocle.Search.Lexer
+                     , Monocle.Search.Parser
+                     , Monocle.Search.Queries
                      , Monocle.Search.Query
                      , Monocle.Search.Syntax
-                     , Monocle.Search.Parser
                      , Monocle.TaskData
                      , Monocle.WebApi
                      , Monocle.Worker

--- a/haskell/monocle.cabal
+++ b/haskell/monocle.cabal
@@ -41,6 +41,7 @@ library
   import:              common-options
   build-depends:       base                       < 5
                      , aeson
+                     , bloodhound                 >= 0.16.0.0
                      , containers                 < 0.7
                      , deepseq                    < 1.5
                      , exceptions                 < 0.11
@@ -68,12 +69,20 @@ library
                      , Monocle.Client
                      , Monocle.Config
                      , Monocle.Search
+                     , Monocle.Search.CLI
                      , Monocle.Search.Lexer
+                     , Monocle.Search.Query
                      , Monocle.Search.Syntax
                      , Monocle.Search.Parser
                      , Monocle.TaskData
                      , Monocle.WebApi
                      , Monocle.Worker
+
+executable monocle-search
+  import:              common-options
+  hs-source-dirs:      app
+  main-is:             Search.hs
+  build-depends:       base, monocle
 
 executable monocle-api
   import:              common-options

--- a/haskell/monocle.cabal
+++ b/haskell/monocle.cabal
@@ -41,6 +41,7 @@ library
   import:              common-options
   build-depends:       base                       < 5
                      , aeson
+                     , aeson-casing
                      , bloodhound                 >= 0.16.0.0
                      , containers                 < 0.7
                      , deepseq                    < 1.5
@@ -69,6 +70,7 @@ library
                      , Monocle.Client
                      , Monocle.Config
                      , Monocle.Search
+                     , Monocle.Search.Change
                      , Monocle.Search.CLI
                      , Monocle.Search.Lexer
                      , Monocle.Search.Query

--- a/haskell/src/Monocle/Search/CLI.hs
+++ b/haskell/src/Monocle/Search/CLI.hs
@@ -11,6 +11,7 @@ import qualified Database.Bloodhound as BH
 import Monocle.Search.Change (Change (..))
 import qualified Monocle.Search.Parser as P
 import qualified Monocle.Search.Query as Q
+import Monocle.Search.Syntax (SortOrder (..))
 import Relude
 
 parseQuery :: Text -> Text
@@ -44,11 +45,14 @@ runQuery bhEnv index queryBase =
         { BH.size = BH.Size (Q.queryLimit queryBase),
           BH.sortBody = toSortBody <$> Q.queryOrder queryBase
         }
-    toSortBody field =
+    toSortBody (field, order) =
       [ BH.DefaultSortSpec
-          ( BH.DefaultSort (BH.FieldName field) BH.Descending Nothing Nothing Nothing Nothing
+          ( BH.DefaultSort (BH.FieldName field) (sortOrder order) Nothing Nothing Nothing Nothing
           )
       ]
+    sortOrder order = case order of
+      Asc -> BH.Ascending
+      Desc -> BH.Descending
 
 searchMain :: MonadIO m => m ()
 searchMain = do

--- a/haskell/src/Monocle/Search/CLI.hs
+++ b/haskell/src/Monocle/Search/CLI.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- |
+module Monocle.Search.CLI (searchMain) where
+
+import qualified Data.Aeson as Aeson
+import qualified Database.Bloodhound as BH
+import qualified Monocle.Search.Parser as P
+import qualified Monocle.Search.Query as Q
+import Network.HTTP.Client (Response, defaultManagerSettings, responseBody, responseStatus)
+import Relude
+
+parseQuery :: Text -> Text
+parseQuery code = either id decodeUtf8 query
+  where
+    query = do
+      expr <- P.parse code
+      Aeson.encode <$> Q.query expr
+
+runQuery :: MonadIO m => Text -> Text -> Text -> m ()
+runQuery server index code =
+  liftIO $
+    BH.withBH defaultManagerSettings (BH.Server server) $ do
+      resp <- BH.searchByIndex (BH.IndexName index) search
+      print resp
+  where
+    query = fromRight (error "Invalid query") (P.parse code >>= Q.query)
+    search = BH.mkSearch (Just query) Nothing
+
+searchMain :: MonadIO m => m ()
+searchMain = do
+  args <- map toText <$> getArgs
+  case args of
+    ["--parse", query] -> putTextLn $ parseQuery query
+    [elkUrl, index, query] -> runQuery elkUrl index query
+    _ -> putTextLn "usage: elk-url index query"

--- a/haskell/src/Monocle/Search/CLI.hs
+++ b/haskell/src/Monocle/Search/CLI.hs
@@ -1,17 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 
--- |
-module Monocle.Search.CLI (searchMain, runQuery) where
+-- | monocle-search CLI entry point
+module Monocle.Search.CLI (searchMain) where
 
-import Control.Monad.Catch (MonadThrow)
-import Data.Aeson (FromJSON (..))
 import qualified Data.Aeson as Aeson
-import qualified Database.Bloodhound as BH
-import Monocle.Search.Change (Change (..))
 import qualified Monocle.Search.Parser as P
+import qualified Monocle.Search.Queries as Q
 import qualified Monocle.Search.Query as Q
-import Monocle.Search.Syntax (SortOrder (..))
 import Relude
 
 parseQuery :: Text -> Text
@@ -21,50 +17,21 @@ parseQuery code = either id decodeUtf8 query
       expr <- P.parse code
       Aeson.encode . Q.queryBH <$> Q.queryWithMods expr
 
--- | Helper search func that can be replaced by a scanSearch
-simpleSearch :: (FromJSON a, MonadThrow m, BH.MonadBH m) => BH.IndexName -> BH.Search -> m [BH.Hit a]
-simpleSearch indexName search = do
-  rawResp <- BH.searchByIndex indexName search
-  resp <- BH.parseEsResponse rawResp
-  case resp of
-    Left e -> error (show e)
-    Right x -> pure (BH.hits (BH.searchHits x))
-
-runQuery :: MonadIO m => BH.BHEnv -> Text -> Q.Query -> m [Change]
-runQuery bhEnv index queryBase =
-  liftIO $
-    BH.runBH bhEnv $ do
-      resp <- fmap BH.hitSource <$> simpleSearch (BH.IndexName index) search
-      pure $ catMaybes resp
+printQuery :: MonadIO m => Text -> Text -> Text -> m ()
+printQuery elkUrl index code = do
+  bhEnv <- Q.mkEnv elkUrl
+  changes <- Q.changes bhEnv index query
+  mapM_ (putTextLn . show) (take 2 changes)
+  putTextLn $ "Got : " <> show (length changes) <> " results"
   where
-    query =
-      BH.QueryBoolQuery $
-        BH.mkBoolQuery [BH.TermQuery (BH.Term "type" "Change") Nothing, (Q.queryBH queryBase)] [] [] []
-    search =
-      (BH.mkSearch (Just query) Nothing)
-        { BH.size = BH.Size (Q.queryLimit queryBase),
-          BH.sortBody = toSortBody <$> Q.queryOrder queryBase
-        }
-    toSortBody (field, order) =
-      [ BH.DefaultSortSpec
-          ( BH.DefaultSort (BH.FieldName field) (sortOrder order) Nothing Nothing Nothing Nothing
-          )
-      ]
-    sortOrder order = case order of
-      Asc -> BH.Ascending
-      Desc -> BH.Descending
+    query = case P.parse code >>= Q.queryWithMods of
+      Left err -> error $ "Invalid query: " <> err
+      Right q -> q
 
 searchMain :: MonadIO m => m ()
 searchMain = do
   args <- map toText <$> getArgs
   case args of
     ["--parse", query] -> putTextLn $ parseQuery query
-    [elkUrl, index, code] -> do
-      let query = case P.parse code >>= Q.queryWithMods of
-            Left err -> error $ "Invalid query: " <> err
-            Right q -> q
-      bhEnv <- Q.mkEnv elkUrl
-      changes <- runQuery bhEnv index query
-      mapM_ (putTextLn . show) (take 2 changes)
-      putTextLn $ "Got : " <> show (length changes) <> " results"
+    [elkUrl, index, code] -> printQuery elkUrl index code
     _ -> putTextLn "usage: elk-url index query"

--- a/haskell/src/Monocle/Search/CLI.hs
+++ b/haskell/src/Monocle/Search/CLI.hs
@@ -2,13 +2,15 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 -- |
-module Monocle.Search.CLI (searchMain) where
+module Monocle.Search.CLI (searchMain, runQuery) where
 
+import Control.Monad.Catch (MonadThrow)
+import Data.Aeson (FromJSON (..))
 import qualified Data.Aeson as Aeson
 import qualified Database.Bloodhound as BH
+import Monocle.Search.Change (Change (..))
 import qualified Monocle.Search.Parser as P
 import qualified Monocle.Search.Query as Q
-import Network.HTTP.Client (Response, defaultManagerSettings, responseBody, responseStatus)
 import Relude
 
 parseQuery :: Text -> Text
@@ -18,20 +20,36 @@ parseQuery code = either id decodeUtf8 query
       expr <- P.parse code
       Aeson.encode <$> Q.query expr
 
-runQuery :: MonadIO m => Text -> Text -> Text -> m ()
-runQuery server index code =
+-- | Helper search func that can be replaced by a scanSearch
+simpleSearch :: (FromJSON a, MonadThrow m, BH.MonadBH m) => BH.IndexName -> BH.Search -> m [BH.Hit a]
+simpleSearch indexName search = do
+  rawResp <- BH.searchByIndex indexName search
+  resp <- BH.parseEsResponse rawResp
+  case resp of
+    Left e -> error (show e)
+    Right x -> pure (BH.hits (BH.searchHits x))
+
+runQuery :: MonadIO m => BH.BHEnv -> Text -> BH.Query -> m [Change]
+runQuery bhEnv index queryBase =
   liftIO $
-    BH.withBH defaultManagerSettings (BH.Server server) $ do
-      resp <- BH.searchByIndex (BH.IndexName index) search
-      print resp
+    BH.runBH bhEnv $ do
+      resp <- fmap BH.hitSource <$> simpleSearch (BH.IndexName index) search
+      pure $ catMaybes resp
   where
-    query = fromRight (error "Invalid query") (P.parse code >>= Q.query)
-    search = BH.mkSearch (Just query) Nothing
+    query = BH.QueryBoolQuery $ BH.mkBoolQuery [BH.TermQuery (BH.Term "type" "Change") Nothing, queryBase] [] [] []
+    search = (BH.mkSearch (Just query) Nothing) {BH.size = BH.Size 1000}
 
 searchMain :: MonadIO m => m ()
 searchMain = do
   args <- map toText <$> getArgs
   case args of
     ["--parse", query] -> putTextLn $ parseQuery query
-    [elkUrl, index, query] -> runQuery elkUrl index query
+    [elkUrl, index, code] -> do
+      let query = case P.parse code >>= Q.query of
+            Left err -> error $ "Invalid query: " <> err
+            Right q -> q
+      bhEnv <- Q.mkEnv elkUrl
+      changes <- runQuery bhEnv index query
+      mapM_ (putTextLn . show) (take 2 changes)
+      putTextLn $ "Got : " <> show (length changes) <> " results"
     _ -> putTextLn "usage: elk-url index query"

--- a/haskell/src/Monocle/Search/Change.hs
+++ b/haskell/src/Monocle/Search/Change.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- |
+module Monocle.Search.Change where
+
+import Data.Aeson (FromJSON, ToJSON, genericParseJSON, genericToJSON, parseJSON, toJSON)
+import Data.Aeson.Casing (aesonPrefix, snakeCase)
+import Data.Time.Clock (UTCTime)
+import Relude
+
+data Author = Author
+  {authorMuid :: Text}
+  deriving (Show, Eq, Generic)
+
+instance ToJSON Author where
+  toJSON = genericToJSON $ aesonPrefix snakeCase
+
+instance FromJSON Author where
+  parseJSON = genericParseJSON $ aesonPrefix snakeCase
+
+data Change = Change
+  { changeState :: Text,
+    changeUrl :: Text,
+    changeCreatedAt :: UTCTime,
+    changeUpdatedAt :: UTCTime,
+    changeTitle :: Text,
+    changeRepositoryFullname :: Text,
+    changeAuthor :: Author
+  }
+  deriving (Show, Eq, Generic)
+
+instance ToJSON Change where
+  toJSON = genericToJSON $ aesonPrefix snakeCase
+
+instance FromJSON Change where
+  parseJSON = genericParseJSON $ aesonPrefix snakeCase

--- a/haskell/src/Monocle/Search/Lexer.hs
+++ b/haskell/src/Monocle/Search/Lexer.hs
@@ -30,6 +30,8 @@ data Token
   | LowerEqual
   | -- search operator
     OrderBy
+  | SortAsc
+  | SortDesc
   | Limit
   | -- piority operator
     OpenParenthesis
@@ -50,6 +52,8 @@ tokenParser =
       Not <$ keyword ["not", "NOT"] ["¬", "!"],
       Equal <$ keyword [] [":", "=", "=="],
       OrderBy <$ keyword ["order by", "ORDER BY"] [],
+      SortAsc <$ keyword ["asc", "ASC"] [],
+      SortDesc <$ keyword ["desc", "DESC"] [],
       Limit <$ keyword ["limit", "LIMIT"] [],
       Greater <$ symbol ">",
       GreaterEqual <$ symbol ">=",

--- a/haskell/src/Monocle/Search/Lexer.hs
+++ b/haskell/src/Monocle/Search/Lexer.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- | Monocle search language lexer
+-- The goal of this module is to transform a 'Text'
+-- into a list of 'Token'.
+module Monocle.Search.Lexer (Token (..), lex) where
+
+import qualified Control.Monad.Combinators as Combinators
+import Relude
+import qualified Text.Megaparsec as Megaparsec
+import qualified Text.Megaparsec.Char as Megaparsec.Char
+import qualified Text.Megaparsec.Char.Lexer as Lexer
+
+-- | Short-hand type synonym used by lexing utilities
+type Parser = Megaparsec.Parsec Void Text
+
+-- | The language is composed of the following token:
+data Token
+  = Literal Text
+  | -- boolean operator
+    And
+  | Or
+  | Not
+  | -- field operator
+    Equal
+  | Greater
+  | GreaterEqual
+  | Lower
+  | LowerEqual
+  | -- search operator
+    OrderBy
+  | Limit
+  | -- piority operator
+    OpenParenthesis
+  | CloseParenthesis
+  deriving (Show, Eq, Ord)
+
+-- | 'tokenParser' parses a single token
+--
+-- >>> Megaparsec.parse tokenParser "" "and"
+-- Right And
+-- >>> Megaparsec.parse tokenParser "" "state"
+-- Right (Literal "state")
+tokenParser :: Parser Token
+tokenParser =
+  Combinators.choice
+    [ And <$ keyword ["and", "AND"] ["∧", "&&"],
+      Or <$ keyword ["or", "OR"] ["∨", "||"],
+      Not <$ keyword ["not", "NOT"] ["¬", "!"],
+      Equal <$ keyword [] [":", "=", "=="],
+      OrderBy <$ keyword ["order by", "ORDER BY"] [],
+      Limit <$ keyword ["limit", "LIMIT"] [],
+      Greater <$ symbol ">",
+      GreaterEqual <$ symbol ">=",
+      Lower <$ symbol "<",
+      LowerEqual <$ symbol "<=",
+      OpenParenthesis <$ symbol "(",
+      CloseParenthesis <$ symbol ")",
+      Literal <$> literal
+    ]
+
+-- | 'literal' parses a literal field or value
+literal :: Parser Text
+literal = Lexer.lexeme Megaparsec.Char.space $ Megaparsec.takeWhile1P Nothing isLiteral
+  where
+    isLiteral x = upper x || lower x || digit x || sep x
+    upper c = 'A' <= c && c <= 'Z'
+    lower c = 'a' <= c && c <= 'z'
+    digit c = '0' <= c && c <= '9'
+    sep c = c `elem` ['-', '_', '/']
+
+-- | 'symbol' parses a known symbol
+symbol :: Text -> Parser Text
+symbol = Lexer.symbol Megaparsec.Char.space
+
+-- | 'text' parses a known text with a required trailing space
+name :: Text -> Parser Text
+name = Lexer.symbol $ Megaparsec.Char.space1 <|> Megaparsec.eof
+
+-- | 'keyword' parses a list of known names or symbols
+keyword :: [Text] -> [Text] -> Parser Text
+keyword names symbols =
+  Megaparsec.try $ Combinators.choice (map name names <|> map symbol symbols)
+
+-- | 'tokenParser' parses all the token until the end of file
+tokensParser :: Parser [Token]
+tokensParser = Megaparsec.Char.space *> many tokenParser <* Megaparsec.eof
+
+-- | 'lex' parses the code into a list of 'Token'
+lex :: Text -> Either Text [Token]
+lex code = case Megaparsec.parse tokensParser "<input>" code of
+  Left err -> Left $ show err
+  Right tokens -> Right tokens

--- a/haskell/src/Monocle/Search/Parser.hs
+++ b/haskell/src/Monocle/Search/Parser.hs
@@ -9,7 +9,7 @@ module Monocle.Search.Parser (parse) where
 import qualified Control.Monad.Combinators as Combinators
 import qualified Data.Set as Set
 import Monocle.Search.Lexer (Token (..), lex)
-import Monocle.Search.Syntax (Expr (..))
+import Monocle.Search.Syntax (Expr (..), SortOrder (..))
 import Relude
 import qualified Text.Megaparsec as Megaparsec
 
@@ -69,8 +69,15 @@ exprParserWithMods = do
     modExpr = do
       operatorToken <- tokens [OrderBy, Limit]
       case operatorToken of
-        OrderBy -> OrderByExpr <$> literal
+        OrderBy -> OrderByExpr <$> literal <*> orderSort
         Limit -> LimitExpr <$> intLiteral
+        _ -> error "this should not happen, see the expression before the case statement"
+
+    orderSort = do
+      sortToken <- Combinators.optional $ tokens [SortAsc, SortDesc]
+      pure $ case fromMaybe SortAsc sortToken of
+        SortAsc -> Asc
+        SortDesc -> Desc
         _ -> error "this should not happen, see the expression before the case statement"
 
 -- | 'intLiteral' parses a number

--- a/haskell/src/Monocle/Search/Parser.hs
+++ b/haskell/src/Monocle/Search/Parser.hs
@@ -1,0 +1,109 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- | Monocle search language parser
+-- The goal of this module is to transform a list of 'token'
+-- into a 'Expr'.
+module Monocle.Search.Parser (parse) where
+
+import qualified Control.Monad.Combinators as Combinators
+import qualified Data.Set as Set
+import Monocle.Search.Lexer (Token (..), lex)
+import Monocle.Search.Syntax (Expr (..))
+import Relude
+import qualified Text.Megaparsec as Megaparsec
+
+-- | Short-hand type synonym used by parsing utilities
+type Parser = Megaparsec.Parsec Void [Token]
+
+-- | 'exprParser' parses an expression
+--
+-- >>> Megaparsec.parse exprParser "" [Literal "status", Equal, Literal "open"]
+-- Right (EqExpr "status" "open")
+exprParser :: Parser Expr
+exprParser = Combinators.choice [Megaparsec.try boolExpr, searchExpr]
+  where
+    -- 'boolExpr' combines multiple expression
+    boolExpr = do
+      -- Here we would like to run 'exprParser' directly, but that will cause
+      -- a left recursion, so we are using a left factoring technique.
+      leftExpr <- closedExpr
+      operatorToken <- tokens [And, Or]
+      case operatorToken of
+        -- For the right expression, it is safe to run 'exprParser'
+        And -> AndExpr leftExpr <$> exprParser
+        Or -> OrExpr leftExpr <$> exprParser
+        _ -> error "this should not happen, see the expression before the case statement"
+
+    -- 'searchExpr' is a single expression (e.g. `a:b`) with optional modifiers (e.g. `order by x`)
+    searchExpr = do
+      expr <- closedExpr
+      modifiers <- Combinators.many modExpr
+      pure $ foldr (\modifier acc -> modifier acc) expr modifiers
+
+    -- 'closedExpr' is a single expression without modifiers
+    closedExpr = Combinators.choice [notExpr, fieldExpr, parenExpr]
+
+    -- 'notExpr' is a negated expression, we run 'closedExpr' so that 'boolExpr' keeps the priority.
+    -- in other words, the 'notExpr' only applies to the next 'closedExpr'.
+    notExpr = token Not >> NotExpr <$> closedExpr
+
+    fieldExpr = do
+      field <- literal
+      operator <- do
+        operatorToken <- tokens [Equal, Greater, Lower, GreaterEqual, LowerEqual]
+        pure $ case operatorToken of
+          Equal -> EqExpr
+          Greater -> GtExpr
+          Lower -> LtExpr
+          GreaterEqual -> GtEqExpr
+          LowerEqual -> LtEqExpr
+          _ -> error "this should not happen, see the expression before the case statement"
+      operator field <$> literal
+
+    parenExpr =
+      -- Here it is safe to run 'exprParser' because 'parenExpr' first parses an 'OpenParenthesis'
+      Combinators.between (token OpenParenthesis) (token CloseParenthesis) exprParser
+
+    -- 'modExpr' is a trailing expression modifiers
+    modExpr = do
+      operatorToken <- tokens [OrderBy, Limit]
+      case operatorToken of
+        OrderBy -> OrderByExpr <$> literal
+        Limit -> LimitExpr <$> intLiteral
+        _ -> error "this should not happen, see the expression before the case statement"
+
+-- | 'intLiteral' parses a number
+intLiteral :: Parser Int
+intLiteral = do
+  strLiteral <- toString <$> literal
+  case readMaybe strLiteral of
+    Just int -> pure int
+    Nothing -> Megaparsec.failure Nothing Set.empty
+
+-- | 'literal' parses a literal token, returning it's value
+literal :: Parser Text
+literal = Megaparsec.token isLiteral Set.empty
+  where
+    isLiteral (Literal v) = Just v
+    isLiteral _ = Nothing
+
+-- | 'token' parses a single token
+token :: Token -> Parser Token
+token token' = Megaparsec.token isToken Set.empty
+  where
+    isToken v
+      | v == token' = Just token'
+      | otherwise = Nothing
+
+-- | 'tokens' parses one of the tokens
+tokens :: [Token] -> Parser Token
+tokens = Combinators.choice . map token
+
+-- | 'parse' parses the code into an 'Expr'
+parse :: Text -> Either Text Expr
+parse code = do
+  tokens' <- lex code
+  case Megaparsec.parse (exprParser <* Megaparsec.eof) "<input>" tokens' of
+    Left err -> Left $ show err
+    Right expr -> Right expr

--- a/haskell/src/Monocle/Search/Queries.hs
+++ b/haskell/src/Monocle/Search/Queries.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- | Monocle queries
+-- The goal of this module is to transform 'Query' into list of items
+module Monocle.Search.Queries where
+
+import Control.Monad.Catch (MonadThrow)
+import Data.Aeson (FromJSON (..))
+import qualified Database.Bloodhound as BH
+import Monocle.Search.Change (Change (..))
+import qualified Monocle.Search.Query as Q
+import Monocle.Search.Syntax (SortOrder (..))
+import qualified Network.HTTP.Client as HTTP
+import Relude
+
+mkEnv :: MonadIO m => Text -> m BH.BHEnv
+mkEnv server = do
+  manager <- liftIO $ HTTP.newManager HTTP.defaultManagerSettings
+  pure $ BH.mkBHEnv (BH.Server server) manager
+
+-- | Helper search func that can be replaced by a scanSearch
+simpleSearch :: (FromJSON a, MonadThrow m, BH.MonadBH m) => BH.IndexName -> BH.Search -> m [BH.Hit a]
+simpleSearch indexName search = do
+  rawResp <- BH.searchByIndex indexName search
+  resp <- BH.parseEsResponse rawResp
+  case resp of
+    Left e -> error (show e)
+    Right x -> pure (BH.hits (BH.searchHits x))
+
+runQuery :: MonadIO m => Text -> BH.BHEnv -> Text -> Q.Query -> m [Change]
+runQuery documentType bhEnv index queryBase =
+  liftIO $
+    BH.runBH bhEnv $ do
+      resp <- fmap BH.hitSource <$> simpleSearch (BH.IndexName index) search
+      pure $ catMaybes resp
+  where
+    query =
+      BH.QueryBoolQuery $
+        BH.mkBoolQuery [BH.TermQuery (BH.Term "type" documentType) Nothing, (Q.queryBH queryBase)] [] [] []
+    search =
+      (BH.mkSearch (Just query) Nothing)
+        { BH.size = BH.Size (Q.queryLimit queryBase),
+          BH.sortBody = toSortBody <$> Q.queryOrder queryBase
+        }
+    toSortBody (field, order) =
+      [ BH.DefaultSortSpec
+          ( BH.DefaultSort (BH.FieldName field) (sortOrder order) Nothing Nothing Nothing Nothing
+          )
+      ]
+    sortOrder order = case order of
+      Asc -> BH.Ascending
+      Desc -> BH.Descending
+
+changes :: MonadIO m => BH.BHEnv -> Text -> Q.Query -> m [Change]
+changes = runQuery "Change"

--- a/haskell/src/Monocle/Search/Query.hs
+++ b/haskell/src/Monocle/Search/Query.hs
@@ -9,7 +9,7 @@ import Data.List (lookup)
 import Data.Time.Clock (UTCTime)
 import Data.Time.Format (defaultTimeLocale, parseTimeM)
 import qualified Database.Bloodhound as BH
-import Monocle.Search.Syntax (Expr (..))
+import Monocle.Search.Syntax (Expr (..), SortOrder (..))
 import qualified Network.HTTP.Client as HTTP
 import Relude
 
@@ -114,15 +114,15 @@ query expr = case expr of
   e@(LtExpr field value) -> mkRangeQuery e field value
   e@(LtEqExpr field value) -> mkRangeQuery e field value
   LimitExpr _ _ -> Left "Limit must be global"
-  OrderByExpr _ _ -> Left "Order by must be global"
+  OrderByExpr _ _ _ -> Left "Order by must be global"
 
-data Query = Query {queryOrder :: Maybe Field, queryLimit :: Int, queryBH :: BH.Query} deriving (Show)
+data Query = Query {queryOrder :: Maybe (Field, SortOrder), queryLimit :: Int, queryBH :: BH.Query} deriving (Show)
 
 queryWithMods :: Expr -> Either Text Query
 queryWithMods baseExpr = Query order limit <$> query expr
   where
     (order, limit, expr) = case baseExpr of
-      OrderByExpr order' (LimitExpr limit' expr') -> (Just order', limit', expr')
+      OrderByExpr order' sortOrder (LimitExpr limit' expr') -> (Just (order', sortOrder), limit', expr')
       LimitExpr limit' expr' -> (Nothing, limit', expr')
       _ -> (Nothing, 100, baseExpr)
 

--- a/haskell/src/Monocle/Search/Query.hs
+++ b/haskell/src/Monocle/Search/Query.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- | Monocle search language query
+-- The goal of this module is to transform a 'Expr' into a 'Bloodhound.Query'
+module Monocle.Search.Query (query) where
+
+import Data.List (lookup)
+import Data.Time.Clock (UTCTime)
+import Data.Time.Format (defaultTimeLocale, parseTimeM)
+import qualified Database.Bloodhound as BH
+import Monocle.Search.Syntax (Expr (..))
+import Relude
+
+data FieldType = FieldDate | FieldNumber | FieldText
+
+type Field = Text
+
+-- | 'fields' specifies how to handle field value
+fields :: [(Field, (FieldType, Field))]
+fields =
+  [ ("updated_at", (FieldDate, "updated_at")),
+    ("score", (FieldNumber, "tasks_data.score")),
+    ("repo", (FieldText, "repository_fullname")),
+    ("author", (FieldText, "author.muid"))
+  ]
+
+-- | 'lookupField' return a field type and actual field name
+lookupField :: Field -> Either Text (FieldType, Field)
+lookupField name = maybe (Left $ "Unknown field: " <> name) Right (lookup name fields)
+
+parseDateValue :: Text -> Either Text UTCTime
+parseDateValue txt = case parseTimeM False defaultTimeLocale "%F" (toString txt) of
+  Just value -> pure value
+  Nothing -> Left $ "Invalid date: " <> txt
+
+parseNumber :: Text -> Either Text Double
+parseNumber txt = case readMaybe (toString txt) of
+  Just value -> pure value
+  Nothing -> Left $ "Invalid number: " <> txt
+
+data RangeOp = Gt | Gte | Lt | Lte
+
+toRangeOp :: Expr -> RangeOp
+toRangeOp expr = case expr of
+  GtExpr _ _ -> Gt
+  LtExpr _ _ -> Lt
+  GtEqExpr _ _ -> Gte
+  LtEqExpr _ _ -> Lte
+  _ -> error "Unsupported range expression"
+
+toRangeValueD :: RangeOp -> (UTCTime -> BH.RangeValue)
+toRangeValueD op = case op of
+  Gt -> BH.RangeDateGt . BH.GreaterThanD
+  Gte -> BH.RangeDateGte . BH.GreaterThanEqD
+  Lt -> BH.RangeDateLt . BH.LessThanD
+  Lte -> BH.RangeDateLte . BH.LessThanEqD
+
+toRangeValue :: RangeOp -> (Double -> BH.RangeValue)
+toRangeValue op = case op of
+  Gt -> BH.RangeDoubleGt . BH.GreaterThan
+  Gte -> BH.RangeDoubleGte . BH.GreaterThanEq
+  Lt -> BH.RangeDoubleLt . BH.LessThan
+  Lte -> BH.RangeDoubleLte . BH.LessThanEq
+
+mkRangeValue :: RangeOp -> Field -> FieldType -> Text -> Either Text BH.RangeValue
+mkRangeValue op field fieldType value = do
+  case fieldType of
+    FieldDate -> toRangeValueD op <$> parseDateValue value
+    FieldNumber -> toRangeValue op <$> parseNumber value
+    _ -> Left $ "Field " <> field <> " does not support range operator"
+
+mkRangeQuery :: Expr -> Field -> Text -> Either Text BH.Query
+mkRangeQuery expr field value = do
+  (fieldType, fieldName) <- lookupField field
+  BH.QueryRangeQuery
+    . BH.mkRangeQuery (BH.FieldName fieldName)
+    <$> mkRangeValue (toRangeOp expr) field fieldType value
+
+mkEqQuery :: Field -> Text -> Either Text BH.Query
+mkEqQuery field value = do
+  (_fieldType, fieldName) <- lookupField field
+  Right $ BH.TermQuery (BH.Term fieldName value) Nothing
+
+data BoolOp = And | Or
+
+mkBoolQuery :: BoolOp -> Expr -> Expr -> Either Text BH.Query
+mkBoolQuery op e1 e2 = do
+  q1 <- query e1
+  q2 <- query e2
+  let (must, should) = case op of
+        And -> ([q1, q2], [])
+        Or -> ([], [q1, q2])
+  pure $ BH.QueryBoolQuery $ BH.mkBoolQuery must [] [] should
+
+mkNotQuery :: Expr -> Either Text BH.Query
+mkNotQuery e1 = do
+  q1 <- query e1
+  pure $ BH.QueryBoolQuery $ BH.mkBoolQuery [] [] [q1] []
+
+-- | 'query' creates an elastic search query
+--
+-- >>> let Right q = (Parser.parse "state:open" >>= query) in putTextLn . decodeUtf8 . Aeson.encode $ q
+-- {"term":{"state":{"value":"open"}}}
+query :: Expr -> Either Text BH.Query
+query expr = case expr of
+  AndExpr e1 e2 -> mkBoolQuery And e1 e2
+  OrExpr e1 e2 -> mkBoolQuery Or e1 e2
+  EqExpr field value -> mkEqQuery field value
+  NotExpr e1 -> mkNotQuery e1
+  e@(GtExpr field value) -> mkRangeQuery e field value
+  e@(GtEqExpr field value) -> mkRangeQuery e field value
+  e@(LtExpr field value) -> mkRangeQuery e field value
+  e@(LtEqExpr field value) -> mkRangeQuery e field value
+  LimitExpr _ _ -> Left "Limit must be global"
+  OrderByExpr _ _ -> Left "Order by must be global"

--- a/haskell/src/Monocle/Search/Query.hs
+++ b/haskell/src/Monocle/Search/Query.hs
@@ -3,14 +3,13 @@
 
 -- | Monocle search language query
 -- The goal of this module is to transform a 'Expr' into a 'Bloodhound.Query'
-module Monocle.Search.Query (Query (..), queryWithMods, query, mkEnv) where
+module Monocle.Search.Query (Query (..), queryWithMods, query) where
 
 import Data.List (lookup)
 import Data.Time.Clock (UTCTime)
 import Data.Time.Format (defaultTimeLocale, parseTimeM)
 import qualified Database.Bloodhound as BH
 import Monocle.Search.Syntax (Expr (..), SortOrder (..))
-import qualified Network.HTTP.Client as HTTP
 import Relude
 
 data FieldType = FieldDate | FieldNumber | FieldText
@@ -125,8 +124,3 @@ queryWithMods baseExpr = Query order limit <$> query expr
       OrderByExpr order' sortOrder (LimitExpr limit' expr') -> (Just (order', sortOrder), limit', expr')
       LimitExpr limit' expr' -> (Nothing, limit', expr')
       _ -> (Nothing, 100, baseExpr)
-
-mkEnv :: MonadIO m => Text -> m BH.BHEnv
-mkEnv server = do
-  manager <- liftIO $ HTTP.newManager HTTP.defaultManagerSettings
-  pure $ BH.mkBHEnv (BH.Server server) manager

--- a/haskell/src/Monocle/Search/Query.hs
+++ b/haskell/src/Monocle/Search/Query.hs
@@ -3,13 +3,14 @@
 
 -- | Monocle search language query
 -- The goal of this module is to transform a 'Expr' into a 'Bloodhound.Query'
-module Monocle.Search.Query (query) where
+module Monocle.Search.Query (query, mkEnv) where
 
 import Data.List (lookup)
 import Data.Time.Clock (UTCTime)
 import Data.Time.Format (defaultTimeLocale, parseTimeM)
 import qualified Database.Bloodhound as BH
 import Monocle.Search.Syntax (Expr (..))
+import qualified Network.HTTP.Client as HTTP
 import Relude
 
 data FieldType = FieldDate | FieldNumber | FieldText
@@ -114,3 +115,8 @@ query expr = case expr of
   e@(LtEqExpr field value) -> mkRangeQuery e field value
   LimitExpr _ _ -> Left "Limit must be global"
   OrderByExpr _ _ -> Left "Order by must be global"
+
+mkEnv :: MonadIO m => Text -> m BH.BHEnv
+mkEnv server = do
+  manager <- liftIO $ HTTP.newManager HTTP.defaultManagerSettings
+  pure $ BH.mkBHEnv (BH.Server server) manager

--- a/haskell/src/Monocle/Search/Syntax.hs
+++ b/haskell/src/Monocle/Search/Syntax.hs
@@ -1,13 +1,15 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 -- | The Monocle Search Language Syntax
-module Monocle.Search.Syntax (Expr (..)) where
+module Monocle.Search.Syntax (Expr (..), SortOrder (..)) where
 
 import Relude
 
 type Field = Text
 
 type Value = Text
+
+data SortOrder = Asc | Desc deriving (Show, Eq)
 
 data Expr
   = AndExpr Expr Expr
@@ -20,6 +22,6 @@ data Expr
   | GtEqExpr Field Value
   | LtEqExpr Field Value
   | -- Search operator
-    OrderByExpr Field Expr
+    OrderByExpr Field SortOrder Expr
   | LimitExpr Int Expr
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq)

--- a/haskell/src/Monocle/Search/Syntax.hs
+++ b/haskell/src/Monocle/Search/Syntax.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- | The Monocle Search Language Syntax
+module Monocle.Search.Syntax (Expr (..)) where
+
+import Relude
+
+type Field = Text
+
+type Value = Text
+
+data Expr
+  = AndExpr Expr Expr
+  | OrExpr Expr Expr
+  | NotExpr Expr
+  | -- Field operator
+    EqExpr Field Value
+  | GtExpr Field Value
+  | LtExpr Field Value
+  | GtEqExpr Field Value
+  | LtEqExpr Field Value
+  | -- Search operator
+    OrderByExpr Field Expr
+  | LimitExpr Int Expr
+  deriving (Show, Eq, Ord)

--- a/haskell/test/Spec.hs
+++ b/haskell/test/Spec.hs
@@ -6,6 +6,9 @@ module Main (main) where
 import Google.Protobuf.Timestamp
 import Monocle.Client
 import Monocle.Mock
+import qualified Monocle.Search.Lexer as L
+import qualified Monocle.Search.Parser as P
+import qualified Monocle.Search.Syntax as S
 import Monocle.TaskData
 import Monocle.WebApi
 import Relude
@@ -13,7 +16,55 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 main :: IO ()
-main = defaultMain (testGroup "Tests" [monocleWebApiTests])
+main = defaultMain (testGroup "Tests" [monocleSearchLanguage, monocleWebApiTests])
+
+monocleSearchLanguage :: TestTree
+monocleSearchLanguage =
+  testGroup
+    "Monocle.Search"
+    [ testCase
+        "Lexer basic"
+        ( lexMatch "state:open" [L.Literal "state", L.Equal, L.Literal "open"]
+        ),
+      testCase
+        "Parser basic"
+        (parseMatch "state:open" (S.EqExpr "state" "open")),
+      testCase
+        "Lexer paren"
+        ( lexMatch
+            "(a>42 or a = 0) and b: d"
+            [ L.OpenParenthesis,
+              L.Literal "a",
+              L.Greater,
+              L.Literal "42",
+              L.Or,
+              L.Literal "a",
+              L.Equal,
+              L.Literal "0",
+              L.CloseParenthesis,
+              L.And,
+              L.Literal "b",
+              L.Equal,
+              L.Literal "d"
+            ]
+        ),
+      testCase
+        "Parser paren"
+        ( parseMatch
+            "(a>42 or a:0) and b:d"
+            ( (S.AndExpr (S.OrExpr (S.GtExpr "a" "42") (S.EqExpr "a" "0")) (S.EqExpr "b" "d"))
+            )
+        ),
+      testCase
+        "Parser order by"
+        ( parseMatch
+            "state:open order by review_date"
+            (S.OrderByExpr "review_date" (S.EqExpr "state" "open"))
+        )
+    ]
+  where
+    lexMatch code tokens = assertEqual "match" (Right tokens) (L.lex code)
+    parseMatch code expr = assertEqual "match" (Right expr) (P.parse code)
 
 monocleWebApiTests :: TestTree
 monocleWebApiTests =

--- a/haskell/test/Spec.hs
+++ b/haskell/test/Spec.hs
@@ -59,7 +59,13 @@ monocleSearchLanguage =
         "Parser order by"
         ( parseMatch
             "state:open order by review_date"
-            (S.OrderByExpr "review_date" (S.EqExpr "state" "open"))
+            (S.OrderByExpr "review_date" S.Asc (S.EqExpr "state" "open"))
+        ),
+      testCase
+        "Parser order by sort"
+        ( parseMatch
+            "state:open order by review_date desc"
+            (S.OrderByExpr "review_date" S.Desc (S.EqExpr "state" "open"))
         )
     ]
   where

--- a/haskell/test/Spec.hs
+++ b/haskell/test/Spec.hs
@@ -69,7 +69,7 @@ monocleSearchLanguage =
         )
     ]
   where
-    lexMatch code tokens = assertEqual "match" (Right tokens) (L.lex code)
+    lexMatch code tokens = assertEqual "match" (Right tokens) (fmap L.token <$> L.lex code)
     parseMatch code expr = assertEqual "match" (Right expr) (P.parse code)
 
 monocleWebApiTests :: TestTree


### PR DESCRIPTION
Related:
- #344 : query language may be used to defined board kanban column content
- #265 : operator may be implemented to define full text search
- #167 : `state: open and updated_at < now-2week`
- #166 : `state: open and review_count: 0`
- #112 : `state: open and approval_count: 0`
- #111 : `state: open and approval_count > 0`
