### PR TITLE
Add default http://localhost:8080 to PUBLIC_URL when unset

### DIFF
--- a/docker-compose.dhall
+++ b/docker-compose.dhall
@@ -113,7 +113,8 @@ let createApiService =
                         , mapValue = "\${GITHUB_CLIENT_SECRET:-}"
                         }
                       , { mapKey = "PUBLIC_URL"
-                        , mapValue = "\${MONOCLE_PUBLIC_URL}"
+                        , mapValue =
+                            "\${MONOCLE_PUBLIC_URL:-http://localhost:8080}"
                         }
                       ]
                   )
@@ -173,7 +174,8 @@ let createWebService =
               , environment = Some
                   ( Compose.ListOrDict.Dict
                       [ { mapKey = "REACT_APP_API_URL"
-                        , mapValue = "\${MONOCLE_PUBLIC_URL}"
+                        , mapValue =
+                            "\${MONOCLE_PUBLIC_URL:-http://localhost:8080}"
                         }
                       , { mapKey = "REACT_APP_TITLE"
                         , mapValue = "\${MONOCLE_TITLE}"

--- a/docker-compose.yml.dev
+++ b/docker-compose.yml.dev
@@ -9,7 +9,7 @@ services:
       CLIENT_SECRET: "${GITHUB_CLIENT_SECRET:-}"
       CONFIG: /etc/monocle/config.yaml
       ELASTIC_CONN: elastic:9200
-      PUBLIC_URL: "${MONOCLE_PUBLIC_URL}"
+      PUBLIC_URL: "${MONOCLE_PUBLIC_URL:-http://localhost:8080}"
     healthcheck:
       retries: 6
       test: "python -c \"import requests,sys; r=requests.get('http://localhost:9876/api/0/health'); print(r.text); sys.exit(1) if r.status_code!=200 else sys.exit(0)\""
@@ -54,7 +54,7 @@ services:
     depends_on:
       - api
     environment:
-      REACT_APP_API_URL: "${MONOCLE_PUBLIC_URL}"
+      REACT_APP_API_URL: "${MONOCLE_PUBLIC_URL:-http://localhost:8080}"
       REACT_APP_TITLE: "${MONOCLE_TITLE}"
     ports:
       - "${MONOCLE_WEB_ADDR:-0.0.0.0}:${MONOCLE_WEB_PORT:-8080}:8080"

--- a/docker-compose.yml.img
+++ b/docker-compose.yml.img
@@ -8,7 +8,7 @@ services:
       CLIENT_SECRET: "${GITHUB_CLIENT_SECRET:-}"
       CONFIG: /etc/monocle/config.yaml
       ELASTIC_CONN: elastic:9200
-      PUBLIC_URL: "${MONOCLE_PUBLIC_URL}"
+      PUBLIC_URL: "${MONOCLE_PUBLIC_URL:-http://localhost:8080}"
     healthcheck:
       retries: 6
       test: "python -c \"import requests,sys; r=requests.get('http://localhost:9876/api/0/health'); print(r.text); sys.exit(1) if r.status_code!=200 else sys.exit(0)\""
@@ -53,7 +53,7 @@ services:
     depends_on:
       - api
     environment:
-      REACT_APP_API_URL: "${MONOCLE_PUBLIC_URL}"
+      REACT_APP_API_URL: "${MONOCLE_PUBLIC_URL:-http://localhost:8080}"
       REACT_APP_TITLE: "${MONOCLE_TITLE}"
     image: "changemetrics/monocle_web:${MONOCLE_VERSION:-latest}"
     ports:


### PR DESCRIPTION
W/o this default setting a local deployment will get an empty string
in place of the API base url.