### PR TITLE
[api] Reexport Google.Protobuf.Timestamp

### DIFF
--- a/haskell/monocle.cabal
+++ b/haskell/monocle.cabal
@@ -70,6 +70,7 @@ library
                      , Monocle.TaskData
                      , Monocle.WebApi
                      , Monocle.Worker
+  reexported-modules:  Google.Protobuf.Timestamp
 
 executable monocle-api
   import:              common-options


### PR DESCRIPTION
This change re-export the timestamp module for lentille.

Fixes: https://github.com/change-metrics/lentille/pull/18