### PR TITLE
[search] Add state and relative date

### DIFF
--- a/haskell/src/Monocle/Search/CLI.hs
+++ b/haskell/src/Monocle/Search/CLI.hs
@@ -5,33 +5,35 @@
 module Monocle.Search.CLI (searchMain) where
 
 import qualified Data.Aeson as Aeson
+import Data.Time.Clock (UTCTime, getCurrentTime)
 import qualified Monocle.Search.Parser as P
 import qualified Monocle.Search.Queries as Q
 import qualified Monocle.Search.Query as Q
 import Relude
 
-parseQuery :: Text -> Text
-parseQuery code = either show decodeUtf8 query
+parseQuery :: UTCTime -> Text -> Text
+parseQuery now code = either show decodeUtf8 query
   where
     query = do
       expr <- P.parse code
-      Aeson.encode . Q.queryBH <$> Q.queryWithMods expr
+      Aeson.encode . Q.queryBH <$> Q.queryWithMods now expr
 
-printQuery :: MonadIO m => Text -> Text -> Text -> m ()
-printQuery elkUrl index code = do
+printQuery :: MonadIO m => UTCTime -> Text -> Text -> Text -> m ()
+printQuery now elkUrl index code = do
   bhEnv <- Q.mkEnv elkUrl
   changes <- Q.changes bhEnv index query
   mapM_ (putTextLn . show) (take 2 changes)
   putTextLn $ "Got : " <> show (length changes) <> " results"
   where
-    query = case P.parse code >>= Q.queryWithMods of
+    query = case P.parse code >>= Q.queryWithMods now of
       Left err -> error $ "Invalid query: " <> show err
       Right q -> q
 
 searchMain :: MonadIO m => m ()
 searchMain = do
+  now <- liftIO getCurrentTime
   args <- map toText <$> getArgs
   case args of
-    ["--parse", query] -> putTextLn $ parseQuery query
-    [elkUrl, index, code] -> printQuery elkUrl index code
+    ["--parse", query] -> putTextLn $ parseQuery now query
+    [elkUrl, index, code] -> printQuery now elkUrl index code
     _ -> putTextLn "usage: elk-url index query"

--- a/haskell/src/Monocle/Search/Query.hs
+++ b/haskell/src/Monocle/Search/Query.hs
@@ -48,9 +48,11 @@ lookupField :: Field -> Either Text (FieldType, Field, Text)
 lookupField name = maybe (Left $ "Unknown field: " <> name) Right (lookup name fields)
 
 parseDateValue :: Text -> Either Text UTCTime
-parseDateValue txt = case parseTimeM False defaultTimeLocale "%F" (toString txt) of
+parseDateValue txt = case tryParse "%F" <|> tryParse "%Y-%m" <|> tryParse "%Y" of
   Just value -> pure value
   Nothing -> Left $ "Invalid date: " <> txt
+  where
+    tryParse fmt = parseTimeM False defaultTimeLocale fmt (toString txt)
 
 parseNumber :: Text -> Either Text Double
 parseNumber txt = case readMaybe (toString txt) of

--- a/haskell/test/Spec.hs
+++ b/haskell/test/Spec.hs
@@ -107,16 +107,23 @@ monocleSearchLanguage =
         ( queryMatch
             "updated_at > 2021 and updated_at < 2021-05"
             "{\"bool\":{\"must\":[{\"range\":{\"updated_at\":{\"gt\":\"2021-01-01T00:00:00Z\",\"boost\":1}}},{\"range\":{\"updated_at\":{\"lt\":\"2021-05-01T00:00:00Z\",\"boost\":1}}}]}}"
+        ),
+      testCase
+        "Query relative date"
+        ( queryMatch
+            "updated_at > now-3weeks"
+            "{\"range\":{\"updated_at\":{\"gt\":\"2021-05-10T00:00:00Z\",\"boost\":1}}}"
         )
     ]
   where
+    date = fromMaybe (error "nop") (readMaybe "2021-05-31 00:00:00 Z")
     lexMatch code tokens = assertEqual "match" (Right tokens) (fmap L.token <$> L.lex code)
     parseMatch code expr = assertEqual "match" (Right expr) (P.parse code)
     queryMatch code query =
       assertEqual
         "match"
         (Right query)
-        (P.parse code >>= Q.queryWithMods >>= pure . Aeson.encode . Q.queryBH)
+        (P.parse code >>= Q.queryWithMods date >>= pure . Aeson.encode . Q.queryBH)
 
 monocleWebApiTests :: TestTree
 monocleWebApiTests =

--- a/haskell/test/Spec.hs
+++ b/haskell/test/Spec.hs
@@ -101,6 +101,12 @@ monocleSearchLanguage =
         ( queryMatch
             "state: abandoned"
             "{\"term\":{\"state\":{\"value\":\"CLOSED\"}}}"
+        ),
+      testCase
+        "Query date"
+        ( queryMatch
+            "updated_at > 2021 and updated_at < 2021-05"
+            "{\"bool\":{\"must\":[{\"range\":{\"updated_at\":{\"gt\":\"2021-01-01T00:00:00Z\",\"boost\":1}}},{\"range\":{\"updated_at\":{\"lt\":\"2021-05-01T00:00:00Z\",\"boost\":1}}}]}}"
         )
     ]
   where

--- a/haskell/test/Spec.hs
+++ b/haskell/test/Spec.hs
@@ -94,7 +94,13 @@ monocleSearchLanguage =
         "Query regex"
         ( queryMatch
             "repo_regex:openstack/.*nova.*"
-            "{\"regexp\":{\"repo_regex\":{\"flags\":\"ALL\",\"value\":\"openstack/.*nova.*\"}}}"
+            "{\"regexp\":{\"repository_fullname\":{\"flags\":\"ALL\",\"value\":\"openstack/.*nova.*\"}}}"
+        ),
+      testCase
+        "Query state"
+        ( queryMatch
+            "state: abandoned"
+            "{\"term\":{\"state\":{\"value\":\"CLOSED\"}}}"
         )
     ]
   where


### PR DESCRIPTION
This pull request improve the search syntax by adding support for:

- state field, e.g. `state:open`
- short and relative date, e.g. `updated_at > now-3weeks`