### PR TITLE
codegen-haskell: Fix missing include to protobuf-src

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ codegen-stubs:
 	rm -Rf srcgen/
 
 codegen-haskell:
-	sh -c 'for pb in $(MESSAGES); do compile-proto-file --includeDir /usr/include --includeDir protos/ --proto $${pb} --out haskell/src/; done'
+	sh -c 'for pb in $(MESSAGES); do compile-proto-file --includeDir /usr/include --includeDir protos/ --includeDir ${PROTOBUF_SRC} --proto $${pb} --out haskell/src/; done'
 	find haskell/ -type f -name "*.hs" -exec ormolu -i {} \;
 
 codegen-python:

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -75,6 +75,7 @@ in rec {
     buildInputs = all-req;
     shellHook = ''
       export PROTOC_FLAGS="-I ${googleapis-src}/ -I ${protobuf-src}/src"
+      export PROTOBUF_SRC=${protobuf-src}/src
       eval $(egrep ^export ${ghc}/bin/ghc)
     '';
   };


### PR DESCRIPTION
Error was:
sh -c 'for pb in monocle/config.proto monocle/search.proto monocle/task_data.proto; do compile-proto-file --includeDir /usr/include --includeDir protos/ --proto ${pb} --out haskell/src/; done'
Error: while processing include statements in "monocle/search.proto", failed
to find the imported file "google/protobuf/timestamp.proto", after looking in the following
locations (controlled via the --includeDir switch(es)):

  /usr/include/google/protobuf/timestamp.proto
  protos/google/protobuf/timestamp.proto