### PR TITLE
[api] Add offset to the getLastUpdated message

### DIFF
--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -482,6 +482,9 @@ components:
                 entity_type:
                     type: integer
                     format: enum
+                offset:
+                    type: integer
+                    format: uint32
         monocle_crawler_CommitInfoResponse:
             properties:
                 error:

--- a/haskell/codegen/Monocle/Crawler.hs
+++ b/haskell/codegen/Monocle/Crawler.hs
@@ -1240,7 +1240,8 @@ data CommitInfoRequest = CommitInfoRequest
     commitInfoRequestCrawler :: Hs.Text,
     commitInfoRequestEntityType ::
       HsProtobuf.Enumerated
-        Monocle.Crawler.CommitInfoRequest_EntityType
+        Monocle.Crawler.CommitInfoRequest_EntityType,
+    commitInfoRequestOffset :: Hs.Word32
   }
   deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic, Hs.NFData)
 
@@ -1255,7 +1256,8 @@ instance HsProtobuf.Message CommitInfoRequest where
     CommitInfoRequest
       { commitInfoRequestIndex = commitInfoRequestIndex,
         commitInfoRequestCrawler = commitInfoRequestCrawler,
-        commitInfoRequestEntityType = commitInfoRequestEntityType
+        commitInfoRequestEntityType = commitInfoRequestEntityType,
+        commitInfoRequestOffset = commitInfoRequestOffset
       } =
       ( Hs.mconcat
           [ ( HsProtobuf.encodeMessageField
@@ -1269,6 +1271,10 @@ instance HsProtobuf.Message CommitInfoRequest where
             ( HsProtobuf.encodeMessageField
                 (HsProtobuf.FieldNumber 3)
                 commitInfoRequestEntityType
+            ),
+            ( HsProtobuf.encodeMessageField
+                (HsProtobuf.FieldNumber 4)
+                commitInfoRequestOffset
             )
           ]
       )
@@ -1285,6 +1291,10 @@ instance HsProtobuf.Message CommitInfoRequest where
       <*> ( HsProtobuf.at
               HsProtobuf.decodeMessageField
               (HsProtobuf.FieldNumber 3)
+          )
+      <*> ( HsProtobuf.at
+              HsProtobuf.decodeMessageField
+              (HsProtobuf.FieldNumber 4)
           )
   dotProto _ =
     [ ( HsProtobuf.DotProtoField
@@ -1309,17 +1319,32 @@ instance HsProtobuf.Message CommitInfoRequest where
           (HsProtobuf.Single "entity_type")
           []
           ""
+      ),
+      ( HsProtobuf.DotProtoField
+          (HsProtobuf.FieldNumber 4)
+          (HsProtobuf.Prim HsProtobuf.UInt32)
+          (HsProtobuf.Single "offset")
+          []
+          ""
       )
     ]
 
 instance HsJSONPB.ToJSONPB CommitInfoRequest where
-  toJSONPB (CommitInfoRequest f1 f2 f3) =
+  toJSONPB (CommitInfoRequest f1 f2 f3 f4) =
     ( HsJSONPB.object
-        ["index" .= f1, "crawler" .= f2, "entity_type" .= f3]
+        [ "index" .= f1,
+          "crawler" .= f2,
+          "entity_type" .= f3,
+          "offset" .= f4
+        ]
     )
-  toEncodingPB (CommitInfoRequest f1 f2 f3) =
+  toEncodingPB (CommitInfoRequest f1 f2 f3 f4) =
     ( HsJSONPB.pairs
-        ["index" .= f1, "crawler" .= f2, "entity_type" .= f3]
+        [ "index" .= f1,
+          "crawler" .= f2,
+          "entity_type" .= f3,
+          "offset" .= f4
+        ]
     )
 
 instance HsJSONPB.FromJSONPB CommitInfoRequest where
@@ -1329,6 +1354,7 @@ instance HsJSONPB.FromJSONPB CommitInfoRequest where
         ( \obj ->
             (Hs.pure CommitInfoRequest) <*> obj .: "index" <*> obj .: "crawler"
               <*> obj .: "entity_type"
+              <*> obj .: "offset"
         )
     )
 
@@ -1348,11 +1374,14 @@ instance HsJSONPB.ToSchema CommitInfoRequest where
       commitInfoRequestCrawler <- declare_crawler Proxy.Proxy
       let declare_entity_type = HsJSONPB.declareSchemaRef
       commitInfoRequestEntityType <- declare_entity_type Proxy.Proxy
+      let declare_offset = HsJSONPB.declareSchemaRef
+      commitInfoRequestOffset <- declare_offset Proxy.Proxy
       let _ =
             Hs.pure CommitInfoRequest
               <*> HsJSONPB.asProxy declare_index
               <*> HsJSONPB.asProxy declare_crawler
               <*> HsJSONPB.asProxy declare_entity_type
+              <*> HsJSONPB.asProxy declare_offset
       Hs.return
         ( HsJSONPB.NamedSchema
             { HsJSONPB._namedSchemaName =
@@ -1370,7 +1399,8 @@ instance HsJSONPB.ToSchema CommitInfoRequest where
                           ("crawler", commitInfoRequestCrawler),
                           ( "entity_type",
                             commitInfoRequestEntityType
-                          )
+                          ),
+                          ("offset", commitInfoRequestOffset)
                         ]
                   }
             }

--- a/haskell/src/Monocle/Api/Server.hs
+++ b/haskell/src/Monocle/Api/Server.hs
@@ -226,7 +226,7 @@ crawlerCommit request = do
 crawlerCommitInfo :: CrawlerPB.CommitInfoRequest -> AppM CrawlerPB.CommitInfoResponse
 crawlerCommitInfo request = do
   Env {tenants = tenants} <- ask
-  let (CrawlerPB.CommitInfoRequest indexName crawlerName entity) = request
+  let (CrawlerPB.CommitInfoRequest indexName crawlerName entity offset) = request
       entityType = fromPBEnum entity
 
   let requestE = do
@@ -242,7 +242,7 @@ crawlerCommitInfo request = do
 
   case requestE of
     Right (index, worker) -> runTenantM index $ do
-      (name, ts) <- I.getLastUpdated worker entityType
+      (name, ts) <- I.getLastUpdated worker entityType offset
       pure
         . CrawlerPB.CommitInfoResponse
         . Just

--- a/haskell/src/Monocle/Backend/Test.hs
+++ b/haskell/src/Monocle/Backend/Test.hs
@@ -176,23 +176,23 @@ testProjectCrawlerMetadata = withTenant doTest
     doTest = do
       -- Init default crawler metadata and Ensure we get the default updated date
       I.initCrawlerMetadata worker
-      lastUpdated <- I.getLastUpdated worker entityType
+      lastUpdated <- I.getLastUpdated worker entityType 0
       assertEqual' "check got oldest updated entity" fakeDefaultDate $ snd lastUpdated
 
       -- Update some crawler metadata and ensure we get the oldest (name, last_commit_at)
       I.setLastUpdated crawlerName fakeDateB entity
       I.setLastUpdated crawlerName fakeDateA entityAlt
-      lastUpdated' <- I.getLastUpdated worker entityType
+      lastUpdated' <- I.getLastUpdated worker entityType 0
       assertEqual' "check got oldest updated entity" ("nova", fakeDateB) lastUpdated'
 
       -- Update one crawler and ensure we get the right oldest
       I.setLastUpdated crawlerName fakeDateC entity
-      lastUpdated'' <- I.getLastUpdated worker entityType
+      lastUpdated'' <- I.getLastUpdated worker entityType 0
       assertEqual' "check got oldest updated entity" ("neutron", fakeDateA) lastUpdated''
 
       -- Re run init and ensure it was noop
       I.initCrawlerMetadata worker
-      lastUpdated''' <- I.getLastUpdated worker entityType
+      lastUpdated''' <- I.getLastUpdated worker entityType 0
       assertEqual' "check got oldest updated entity" ("neutron", fakeDateA) lastUpdated'''
       where
         entityType = CrawlerPB.CommitInfoRequest_EntityTypeProject
@@ -222,7 +222,7 @@ testOrganizationCrawlerMetadata = withTenant doTest
     doTest = do
       -- Init crawler entities metadata and check we get the default date
       I.initCrawlerMetadata worker
-      lastUpdated <- I.getLastUpdated worker entityType
+      lastUpdated <- I.getLastUpdated worker entityType 0
       assertEqual' "check got oldest updated entity" fakeDefaultDate $ snd lastUpdated
 
       -- TODO(fbo) extract Server.AddProjects and use it directly
@@ -234,7 +234,7 @@ testOrganizationCrawlerMetadata = withTenant doTest
 
       -- Update the crawler metadata
       I.setLastUpdated crawlerName fakeDateA $ Organization "gitlab-org"
-      lastUpdated' <- I.getLastUpdated worker entityType
+      lastUpdated' <- I.getLastUpdated worker entityType 0
       assertEqual' "check got oldest updated entity" ("gitlab-org", fakeDateA) lastUpdated'
       where
         entityType = CrawlerPB.CommitInfoRequest_EntityTypeOrganization

--- a/protos/monocle/crawler.proto
+++ b/protos/monocle/crawler.proto
@@ -72,6 +72,7 @@ message CommitInfoRequest {
   string index = 1;
   string crawler = 2;
   EntityType entity_type = 3;
+  uint32 offset = 4;
 }
 
 enum CommitInfoError {


### PR DESCRIPTION
This change enables the macroscope to skip broken entities by
adding an offset to the request.