### PR TITLE
Fix cabal repl usage and adds emacs launcher

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,7 @@ server {
 
 ```ShellSession
 cd haskell
-cabal repl
+cabal repl monocle
 λ> import Monocle.Api.CLI
 λ> run 9879 "http://localhost:9200" "../etc/config.yaml"
 ```
@@ -167,29 +167,25 @@ This section describes how to start the Monocle services directly on your host u
 #### Elastic
 
 ```ShellSession
-nix-shell
-elk-start
+nix-shell --command elk-start
 ```
 
 #### Nginx
 
 ```ShellSession
-nix-shell
-nginx-start
+nix-shell --command nginx-start
 ```
 
 #### APIv1
 
 ```ShellSession
-nix-shell
-monocle-api-start
+nix-shell --command monocle-api-start
 ```
 
 #### APIv2
 
 ```ShellSession
-nix-shell
-monocle-api2-start
+nix-shell --command monocle-api2-start
 λ> import Monocle.Api.CLI
 λ> run 19875 "http://localhost:19200" "../etc/config.yaml"
 ```
@@ -197,9 +193,16 @@ monocle-api2-start
 #### Web
 
 ```ShellSession
-nix-shell
-monocle-web-start
+nix-shell --command monocle-web-start
 firefox http://localhost:13000
+```
+
+#### Launch with emacs lisp
+
+The above commands can be started in emacs buffer using:
+
+```ShellSession
+nix-shell --command launch-monocle-with-emacs
 ```
 
 ## Contributing a new driver

--- a/haskell/README.md
+++ b/haskell/README.md
@@ -17,5 +17,5 @@ dnf install -y ghc cabal-install zlib-devel git && cabal update
 cabal test all
 
 # Start a repl:
-cabal repl
+cabal repl monocle
 ```

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -31,6 +31,7 @@ let
     '';
   };
   elkStart = pkgs.writeScriptBin "elk-start" ''
+    #!/bin/sh
     # todo: only set max_map_count when necessary
     ${pkgs.sudo}/bin/sudo sysctl -w vm.max_map_count=262144
     set -ex
@@ -43,8 +44,12 @@ let
     cat ${elkConf} > $ES_HOME/config/elasticsearch.yml
     exec ${elk}/bin/elasticsearch -p $ES_HOME/pid
   '';
-  elkStop = pkgs.writeScriptBin "elk-stop" "kill $(cat /tmp/es-home/pid)";
+  elkStop = pkgs.writeScriptBin "elk-stop" ''
+    #!/bin/sh
+    kill $(cat /tmp/es-home/pid)
+  '';
   elkDestroy = pkgs.writeScriptBin "elk-destroy" ''
+    #!/bin/sh
     set -x
     [ -f ${elk-home}/pid ] && (${elkStop}/bin/elkstop; sleep 5)
     rm -Rf ${elk-home}/
@@ -108,6 +113,7 @@ let
     '';
   };
   nginxStart = pkgs.writeScriptBin "nginx-start" ''
+    #!/bin/sh
     set -ex
     mkdir -p ${nginx-home};
     exec ${pkgs.nginx}/bin/nginx -c ${nginxConf} -p ${nginx-home}/ -g "daemon off;"
@@ -115,6 +121,7 @@ let
 
   monocle-home = "/tmp/monocle-home";
   monocleApiStart = pkgs.writeScriptBin "monocle-api-start" ''
+    #!/bin/sh
     set -ex
     if ! test -d ${monocle-home}; then
         ${pkgs.python3}/bin/python -mvenv ${monocle-home}
@@ -133,11 +140,13 @@ let
   '';
 
   monocleApi2Start = pkgs.writeScriptBin "monocle-api2-start" ''
+    #!/bin/sh
     set -ex
-    cd haskell; cabal repl
+    cd haskell; cabal repl monocle
   '';
 
   monocleWebStart = pkgs.writeScriptBin "monocle-web-start" ''
+    #!/bin/sh
     set -ex
     cd web
 
@@ -151,8 +160,58 @@ let
     exec ${pkgs.nodejs}/bin/npm start
   '';
 
-  services-req =
-    [ elkStart nginxStart monocleApiStart monocleApi2Start monocleWebStart ];
+  monocleEmacsLauncher = pkgs.writeTextFile {
+    name = "monocle.el";
+    text = ''
+      ;;; monocle.el --- Functions to operate Monocle
+
+      ;; This file is not part of GNU Emacs.
+
+      ;;; Code:
+
+      ;; Start a process in a buffer with ansi colors
+      (require 'comint)
+      (defun start-worker-process (name program &rest args)
+        (let ((buffer-name (concat "*" name "*")))
+          (message "Starting %s %s" buffer-name program)
+          (let ((*buffer* (get-buffer-create buffer-name)))
+            (if (get-buffer-process *buffer*)
+                (message "Process already running!")
+              (with-current-buffer *buffer*
+                (let ((*proc* (apply 'start-process name buffer-name program args)))
+                  (ansi-color-for-comint-mode-on)
+                  (comint-mode)
+                  (set-process-filter *proc* 'comint-output-filter))))
+            (switch-to-buffer-other-window *buffer*))))
+
+      (defun monocle-startp (name command)
+        (start-worker-process (concat "monocle-" name) (concat command "/bin/" name "-start")))
+
+      (defun monocle-start ()
+        (monocle-startp "elk" "${elkStart}" )
+        (monocle-startp "nginx" "${nginxStart}" )
+        (monocle-startp "monocle-api" "${monocleApiStart}" )
+        (monocle-startp "monocle-api2" "${monocleApi2Start}" )
+        (monocle-startp "monocle-web" "${monocleWebStart}" ))
+
+      (monocle-start)
+    '';
+  };
+
+  monocleEmacsStart = pkgs.writeScriptBin "launch-monocle-with-emacs" ''
+    #!/bin/sh
+    set -ex
+    ${pkgs.emacs-nox}/bin/emacs --quick --load ${monocleEmacsLauncher}
+  '';
+
+  services-req = [
+    elkStart
+    nginxStart
+    monocleApiStart
+    monocleApi2Start
+    monocleWebStart
+    monocleEmacsStart
+  ];
 
   # define the base requirements
   base-req = [ pkgs.bashInteractive pkgs.coreutils pkgs.gnumake ];

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -145,6 +145,12 @@ let
     cd haskell; cabal repl monocle
   '';
 
+  monocleGhcid = pkgs.writeScriptBin "monocle-ghcid" ''
+    #!/bin/sh
+    set -ex
+    cd haskell; ${pkgs.ghcid}/bin/ghcid -c "cabal repl monocle" $*
+  '';
+
   monocleWebStart = pkgs.writeScriptBin "monocle-web-start" ''
     #!/bin/sh
     set -ex
@@ -211,6 +217,7 @@ let
     monocleApi2Start
     monocleWebStart
     monocleEmacsStart
+    monocleGhcid
   ];
 
   # define the base requirements


### PR DESCRIPTION
This change fixes this issue:
  cabal: Cannot open a repl for multiple components at once

This change also includes a emacs-lisp script to launch all
the service at once.