### PR TITLE
[query] Improve repo summary count calculation

### DIFF
--- a/haskell/src/Monocle/Backend/Queries.hs
+++ b/haskell/src/Monocle/Backend/Queries.hs
@@ -362,16 +362,17 @@ getReposSummary = do
     getRepoSummary fn = do
       -- Prepare the queries
       let query = getQueryFromSL ("repo: " <> fn)
-          qf = QueryFlavor OnAuthor UpdatedAt
-          countEvent docType = countEvents qf (query <> [documentType docType])
+          eventQF = QueryFlavor OnAuthor CreatedAt
+          changeQF = QueryFlavor Author UpdatedAt
+          countEvent docType = countEvents eventQF (query <> [documentType docType])
 
       -- Count the events
       totalChanges' <- countEvent "ChangeCreatedEvent"
-      abandonedChanges' <- countEvent "ChangeAbandonedEvent"
+      openChanges' <- countEvents changeQF (changeState "open")
       mergedChanges' <- countEvent "ChangeMergedEvent"
 
       -- Return summary
-      let openChanges' = totalChanges' - (abandonedChanges' + mergedChanges')
+      let abandonedChanges' = totalChanges' - (openChanges' + mergedChanges')
       pure $ RepoSummary fn totalChanges' abandonedChanges' mergedChanges' openChanges'
 
 -- | get authors tops


### PR DESCRIPTION
This change counts the open changes and deduces the abandoned count to
ensure accurate result. This change also fixes the query flavor for
event document type which do not have updated_at field.