### PR TITLE
Add prometheus client to monitor the API

### DIFF
--- a/conf/grafana-dashboard.dhall
+++ b/conf/grafana-dashboard.dhall
@@ -1,0 +1,71 @@
+let Grafana =
+      https://raw.githubusercontent.com/weeezes/dhall-grafana/f78d2887939dcb555a47a4b85a91a3d6b38ec2ea/package.dhall sha256:a0e1b5432090944fa671efce0085c6049019ae0d00ca289c268b4528d1cd39af
+
+let datasource = Some (env:GRAFANA_DATASOURCE as Text ? "Prometheus")
+
+let counter =
+      \(refId : Text) ->
+      \(name : Text) ->
+      \(title : Text) ->
+        Grafana.MetricsTargets.PrometheusTarget
+          Grafana.PrometheusTarget::{
+          , refId
+          , expr = "rate(${name}[5m])"
+          , legendFormat = Some "${title} {{ job }}"
+          }
+
+let gauge =
+      \(refId : Text) ->
+      \(expr : Text) ->
+      \(title : Text) ->
+        Grafana.MetricsTargets.PrometheusTarget
+          Grafana.PrometheusTarget::{
+          , refId
+          , expr
+          , legendFormat = Some "${title} {{ job }}"
+          }
+
+let panel =
+      \(y : Natural) ->
+      \(title : Text) ->
+      \(targets : List Grafana.MetricsTargets) ->
+        Grafana.Panels.mkGraphPanel
+          Grafana.GraphPanel::{
+          , title
+          , gridPos = { x = 0, y, w = 24, h = 6 }
+          , datasource
+          , targets
+          , fill = 0
+          , linewidth = 2
+          }
+
+let panels =
+      [ panel
+          0
+          "Activity"
+          [ counter "A" "http_request_duration_seconds_sum" "Request latencies"
+          ]
+      , panel
+          8
+          "Memory"
+          [ gauge
+              "A"
+              "ghc_gcdetails_live_bytes"
+              "Total amount of live data in the heap."
+          ]
+      , panel 16 "CPU" [ counter "B" "ghc_cpu_seconds_total" "CPU time" ]
+      ]
+
+in  Grafana.Dashboard::{
+    , title = "Monocle"
+    , editable = True
+    , panels = Grafana.Utils.generateIds panels
+    , links =
+      [ Grafana.Link.Type.Link
+          Grafana.LinkExternal::{
+          , title = "Monocle"
+          , url = "https://www.changemetrics.io"
+          , tooltip = "change-metrics/monocle"
+          }
+      ]
+    }

--- a/haskell/monocle.cabal
+++ b/haskell/monocle.cabal
@@ -126,6 +126,9 @@ library
                      , mtl
                      , network-uri                < 2.6.5
                      , parser-combinators         < 1.3
+                     , prometheus-client          ^>= 1.0
+                     , prometheus-metrics-ghc     ^>= 1.0
+                     , wai-middleware-prometheus  ^>= 1.0
                      , proto3-suite               >= 0.4.2
                      , relude                     > 1.0.0.0
                      , retry                      < 0.9

--- a/haskell/src/Monocle/Api.hs
+++ b/haskell/src/Monocle/Api.hs
@@ -12,7 +12,10 @@ import qualified Network.Wai as Wai
 import qualified Network.Wai.Handler.Warp as Warp
 import Network.Wai.Logger (withStdoutLogger)
 import Network.Wai.Middleware.Cors (cors, corsRequestHeaders, simpleCorsResourcePolicy)
+import Network.Wai.Middleware.Prometheus (def, prometheus)
 import Network.Wai.Middleware.Servant.Options (provideOptions)
+import Prometheus (register)
+import Prometheus.Metric.GHC (ghcMetrics)
 import Servant (Handler, hoistServer, serve)
 
 monocleAPI :: Proxy MonocleAPI
@@ -42,6 +45,10 @@ run' port elkUrl configFile glLogger = do
 
   -- TODO: add the aliases to the AppM env to avoid parsing them for each request
 
+  -- Monitoring
+  void $ register ghcMetrics
+  let monitoringMiddleware = prometheus def
+
   bhEnv <- mkEnv elkUrl
   let aEnv = Env {..}
   retry $ liftIO $ traverse_ (\tenant -> runTenantM' bhEnv tenant I.ensureIndex) tenants'
@@ -53,6 +60,7 @@ run' port elkUrl configFile glLogger = do
         settings
         . cors (const $ Just policy)
         . provideOptions monocleAPI
+        . monitoringMiddleware
         $ app (AppEnv {..})
   where
     policy =

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -17,6 +17,8 @@ let
   monocle-port = 19876;
   monocle2-port = 19875;
   web-port = 13000;
+  prom-port = 19090;
+  grafana-port = 19030;
 
   # DB
   info = pkgs.lib.splitString "-" pkgs.stdenv.hostPlatform.system;
@@ -64,6 +66,65 @@ let
     set -x
     [ -f ${elk-home}/pid ] && (${elkStop}/bin/elkstop; sleep 5)
     rm -Rf ${elk-home}/
+  '';
+
+  # Prometheus
+  promConf = pkgs.writeTextFile {
+    name = "prometheus.yml";
+    text = ''
+      global:
+        evaluation_interval: "1m"
+        scrape_interval: "1m"
+        scrape_timeout: "10s"
+      scrape_configs:
+        - job_name: api
+          static_configs:
+            - targets:
+                - localhost:${toString monocle2-port}
+    '';
+  };
+  promStart = pkgs.writeScriptBin "prometheus-start" ''
+    #!/bin/sh
+    exec ${pkgs.prometheus}/bin/prometheus \
+      --config.file=${promConf}            \
+      --web.listen-address="0.0.0.0:${toString prom-port}"
+  '';
+
+  grafana-home = "/tmp/grafana-home";
+  grafanaPromDS = pkgs.writeTextFile {
+    name = "prometheus.yml";
+    text = ''
+      apiVersion: 1
+      datasources:
+      - name: Prometheus
+        type: prometheus
+        access: direct
+        url: http://localhost:${toString prom-port}
+    '';
+  };
+  grafanaConf = pkgs.writeTextFile {
+    name = "grafana.ini";
+    text = ''
+      [security]
+      admin_user = admin
+      admin_password = monocle
+
+      [server]
+      http_port = ${toString grafana-port}
+
+      [plugin.grafana-image-renderer]
+      rendering_ignore_https_errors = true
+    '';
+  };
+  grafanaStart = pkgs.writeScriptBin "grafana-start" ''
+    #!/bin/sh -ex
+    mkdir -p ${grafana-home}
+    ${pkgs.rsync}/bin/rsync -a ${pkgs.grafana}/share/grafana/ ${grafana-home}/
+    find ${grafana-home} -type f | xargs chmod 0600
+    find ${grafana-home} -type d | xargs chmod 0700
+    cd ${grafana-home}
+    cat ${grafanaPromDS} > conf/provisioning/datasources/prometheus.yaml
+    exec ${pkgs.grafana}/bin/grafana-server -config ${grafanaConf}
   '';
 
   # WEB
@@ -227,6 +288,8 @@ let
       (defun monocle-start ()
         (monocle-startp "elk" "${elkStart}" )
         (monocle-startp "nginx" "${nginxStart}" )
+        (monocle-startp "prometheus" "${promStart}" )
+        (monocle-startp "grafana" "${grafanaStart}" )
         (monocle-startp "monocle-api" "${monocleApiStart}" )
         (monocle-startp "monocle-api2" "${monocleApi2Start}" )
         (monocle-startp "monocle-web" "${monocleWebStart}" ))
@@ -244,6 +307,8 @@ let
   services-req = [
     elkStart
     nginxStart
+    promStart
+    grafanaStart
     monocleApiStart
     monocleApi2Start
     monocleWebStart


### PR DESCRIPTION
This change adds a new middleware to serve ghc metrics on the
/metrics endpoint.