### PR TITLE
Improve firstEventDuration computation by using json-syntax

### DIFF
--- a/haskell/monocle.cabal
+++ b/haskell/monocle.cabal
@@ -222,6 +222,14 @@ executable macroscope
   import:              common-options, cli-options
   main-is:             Macroscope.hs
 
+benchmark json-decode
+  import:              common-options
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  build-depends:       base, aeson, bloodhound, byteslice, bytestring, criterion, json-syntax, monocle, text-short, text-time
+  main-is:             JsonDecode.hs
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+
 test-suite monocle-test
   import:              common-options
   type:                exitcode-stdio-1.0

--- a/haskell/monocle.cabal
+++ b/haskell/monocle.cabal
@@ -92,24 +92,26 @@ common cli-options
 
 library
   import:              common-options, codegen
-  build-depends:       MonadRandom
-                     , aeson-casing
+  build-depends:       base                       < 5
+                     , MonadRandom
                      , aeson
-                     , base                       < 5
+                     , aeson-casing
                      , binary                     ^>= 0.8
                      , bloodhound                 >= 0.16.0.0
                      , bugzilla-redhat            >= 0.3.2
                      , bytestring                 >= 0.10
+                     , byteslice                  ^>= 0.2
                      , connection
                      , containers                 ^>= 0.6
-                     , directory
                      , dhall                      ^>= 1.39
                      , dhall-yaml                 ^>= 1.2
+                     , directory
                      , either                     ^>= 5
                      , exceptions                 < 0.11
                      , http-client                < 0.8
                      , http-client-tls            < 0.4
                      , http-types                 ^>=0.12
+                     , json-syntax                ^>= 0.2
                      , lens
                      , megaparsec                 < 10
                      , morpheus-graphql-client    ^>= 0.17
@@ -125,6 +127,8 @@ library
                      , servant-server             ^>= 0.18.2
                      , streaming                  < 0.3
                      , tasty-hunit                < 0.11
+                     , text-short                 ^>= 0.1
+                     , text-time                  ^>= 0.3
                      , time                       < 1.10
                      , transformers
                      , vector
@@ -178,6 +182,9 @@ library
 
                      , Macroscope.Main
                      , Macroscope.Worker
+
+                     -- Fast json helpers
+                     , Json.Extras
 
                      -- Codegen
                      , Monocle.Change

--- a/haskell/src/Database/Bloodhound/Raw.hs
+++ b/haskell/src/Database/Bloodhound/Raw.hs
@@ -1,11 +1,12 @@
 -- | A module for low-level function unavailable in bloodhound
-module Database.Bloodhound.Raw (search, aggWithDocValues) where
+module Database.Bloodhound.Raw (search, searchHit, aggWithDocValues) where
 
 import Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Text as Text
 import qualified Data.Vector as Vector
 import qualified Database.Bloodhound as BH
+import qualified Json.Extras as Json
 import Monocle.Prelude
 import qualified Network.HTTP.Client as HTTP
 import qualified Network.HTTP.Types.Method as HTTP
@@ -17,7 +18,6 @@ dispatch ::
   LByteString ->
   m BH.Reply
 dispatch method url body = do
-  -- monocleLog $ decodeUtf8 body
   initReq <- liftIO $ HTTP.parseRequest (toString url)
   let request =
         initReq
@@ -29,18 +29,21 @@ dispatch method url body = do
   manager <- BH.bhManager <$> BH.getBHEnv
   liftIO $ HTTP.httpLbs request manager
 
+search' :: (MonadIO m, MonadBH m, ToJSON body) => BH.IndexName -> body -> m (BH.Reply)
+search' (BH.IndexName index) body = do
+  BH.Server s <- BH.bhServer <$> BH.getBHEnv
+  let url = Text.intercalate "/" [s, index, "_search"]
+      method = HTTP.methodPost
+  dispatch method url (Aeson.encode body)
+
 search ::
   (MonadIO m, MonadBH m, MonadThrow m) =>
   (Aeson.ToJSON body, Aeson.FromJSON resp) =>
   BH.IndexName ->
   body ->
   m (BH.SearchResult resp)
-search (BH.IndexName index) body = do
-  BH.Server s <- BH.bhServer <$> BH.getBHEnv
-  let url = Text.intercalate "/" [s, index, "_search"]
-      method = HTTP.methodPost
-  rawResp <- dispatch method url (Aeson.encode body)
-  -- monocleLog $ show rawResp
+search index body = do
+  rawResp <- search' index body
   resp <- BH.parseEsResponse rawResp
   case resp of
     Left _e -> handleError rawResp
@@ -49,6 +52,27 @@ search (BH.IndexName index) body = do
     handleError resp = do
       monocleLog (show resp)
       error "Elastic response failed"
+
+-- | A special purpose search implementation that uses the faster json-syntax
+searchHit ::
+  (MonadIO m, MonadBH m) =>
+  (Aeson.ToJSON body) =>
+  BH.IndexName ->
+  body ->
+  m [Json.Value]
+searchHit index body = do
+  rawResp <- search' index body
+  case decodeHits (Json.decodeThrow $ HTTP.responseBody rawResp) of
+    Just xs -> pure xs
+    Nothing -> error $ "Could not find hits in " <> show rawResp
+  where
+    decodeHits :: Json.Value -> Maybe [Json.Value]
+    decodeHits value = do
+      hits <- Json.getAttr "hits" =<< Json.getAttr "hits" value
+      fmap getSource <$> Json.getArray hits
+    getSource value = case Json.getAttr "_source" value of
+      Nothing -> error $ "No source found in: " <> show value
+      Just v -> v
 
 aggWithDocValues :: [(Text, Value)] -> Maybe BH.Query -> Value
 aggWithDocValues agg query =

--- a/haskell/src/Json/Extras.hs
+++ b/haskell/src/Json/Extras.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE PackageImports #-}
+
+-- | Extra functions for json-syntax
+module Json.Extras
+  ( -- * Data types
+    module Json,
+    ShortText,
+    TextShort.toText,
+
+    -- * Extras
+    decodeThrow,
+    getAttr,
+    getArray,
+    getString,
+    getDate,
+  )
+where
+
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Bytes as Bytes
+import Data.Text.Short (ShortText)
+import qualified Data.Text.Short as TextShort
+import qualified Data.Text.Time as TextTime
+import Data.Time.Clock (UTCTime)
+import "json-syntax" Json
+import Relude
+
+decodeThrow :: LBS.ByteString -> Json.Value
+decodeThrow dat = case decode (Bytes.fromByteString (toStrict dat)) of
+  Left e -> error $ "Could not decode: " <> (show e)
+  Right v -> v
+
+-- | 'getAttr' return an object value
+getAttr :: ShortText -> Json.Value -> Maybe Json.Value
+getAttr k v = case v of
+  Json.Object xs -> getFirst $ foldMap getValue' xs
+  _ -> Nothing
+  where
+    getValue' Json.Member {..}
+      | key == k = First $ Just value
+      | otherwise = First Nothing
+
+getString :: Json.Value -> Maybe ShortText
+getString v = case v of
+  Json.String x -> pure x
+  _ -> Nothing
+
+getArray :: Json.Value -> Maybe [Json.Value]
+getArray v = case v of
+  Json.Array xs -> pure $ toList xs
+  _ -> Nothing
+
+getDate :: Json.Value -> Maybe UTCTime
+getDate v = case v of
+  Json.String t -> either (const Nothing) Just $ TextTime.parseUTCTimeOrError (TextShort.toText t)
+  _ -> error "Not a date"

--- a/haskell/test/JsonDecode.hs
+++ b/haskell/test/JsonDecode.hs
@@ -1,0 +1,105 @@
+-- | This application evaluate different strategies to handle elasticsearch search result.
+-- The goal is to compute the average age of a ChangeEvents (created_at - on_created) as
+-- this seems to be a bottleneck of the changes review stats query.
+--
+-- Create a dataset by running: curl http://localhost:9200/index/_search -d '{todo: add type term query}' > data/sample.json
+-- Then run the benchmark using `FP=$(pwd)/data/sample.json cabal bench`
+module Main where
+
+import Criterion.Main
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Bytes as B
+import qualified Data.Text.Short as TextShort
+import qualified Data.Text.Time as T
+import qualified Database.Bloodhound as BH
+import qualified Json as Json
+import Monocle.Backend.Documents as D
+import Monocle.Prelude
+import System.Environment (getEnv)
+
+-- | Test compute metric with Json
+jsonPerf :: LBS.ByteString -> Int
+jsonPerf dat = do
+  case Json.decode (B.fromByteString (toStrict dat)) of
+    Left e -> error (show e)
+    Right v -> fromMaybe (error "failed!") (go v)
+  where
+    getValue k v = case v of
+      Json.Object xs -> getFirst $ foldMap getValue' xs
+      _ -> Nothing
+      where
+        getValue' Json.Member {..}
+          | key == k = First $ Just value
+          | otherwise = First Nothing
+    getArray :: Json.Value -> Maybe [Json.Value]
+    getArray v = case v of
+      Json.Array xs -> pure $ toList xs
+      _ -> Nothing
+    getDate :: Json.Value -> UTCTime
+    getDate v = case v of
+      Json.String t -> either (error "oops") id $ T.parseUTCTimeOrError (TextShort.toText t)
+      _ -> error "Not a date"
+    toDuration :: Json.Value -> Maybe Pico
+    toDuration v' = do
+      v <- getValue "_source" v'
+      createdAt <- getDate <$> getValue "created_at" v
+      onCreatedAt <- getDate <$> getValue "on_created_at" v
+      pure $ elapsedSeconds onCreatedAt createdAt
+    go :: Json.Value -> Maybe Int
+    go e = do
+      hits <- getArray =<< getValue "hits" =<< getValue "hits" e
+      avg <- average $ ((fromMaybe (error "bad hit") . toDuration) <$> hits)
+      pure $ truncate avg
+
+-- | Test decoding Json.Value
+jsonDecode :: LBS.ByteString -> Int
+jsonDecode dat = do
+  case Json.decode (B.fromByteString (toStrict dat)) of
+    Left e -> error (show e)
+    Right _ -> 42
+
+-- | Test decoding simple Aeson.Value
+aesonDecode :: LBS.ByteString -> Int
+aesonDecode dat = do
+  getValue (Aeson.eitherDecode' dat)
+  where
+    getValue :: Either String (BH.SearchResult Aeson.Value) -> Int
+    getValue (Right _) = 42
+    getValue _ = error "oops"
+
+-- | Test decoding the full data type
+aesonDecodeData :: LBS.ByteString -> Int
+aesonDecodeData dat =
+  getELK (Aeson.eitherDecode dat)
+  where
+    getELK :: Either String (BH.SearchResult D.ELKChangeEvent) -> Int
+    getELK (Right _) = 42
+    getELK _ = error "oops"
+
+getData :: IO LBS.ByteString
+getData = do
+  fp <- getEnv "FP"
+  LBS.readFile fp
+
+main :: IO ()
+main = do
+  args <- getArgs
+  case args of
+    ["print"] -> print . jsonPerf =<< getData
+    _ -> do
+      defaultMain
+        [ env getData $ \dat ->
+            bgroup
+              "main"
+              [ bgroup
+                  "duration"
+                  [bench "json" $ whnf jsonPerf dat],
+                bgroup
+                  "decode"
+                  [ bench "decode" $ whnf jsonDecode dat,
+                    bench "aeson-value" $ whnf aesonDecode dat,
+                    bench "aeson-elk" $ whnf aesonDecodeData dat
+                  ]
+              ]
+        ]

--- a/haskell/test/JsonDecode.py
+++ b/haskell/test/JsonDecode.py
@@ -1,0 +1,30 @@
+# A python benchmark equivalent to the JsonDecode.hs
+import time
+import os
+import statistics
+import json
+import iso8601
+
+
+def get_duration(hit):
+    return iso8601.parse_date(hit["created_at"]) - iso8601.parse_date(
+        hit["on_created_at"]
+    )
+
+
+def run(dat):
+    # Decode json value
+    b = json.loads(dat)
+    print("Loading took %.3fms" % (1000 * (time.monotonic() - before)))
+
+    # Compute duration
+    return statistics.mean(
+        [get_duration(hit["_source"]).total_seconds() for hit in b["hits"]["hits"]]
+    )
+
+
+before = time.monotonic()
+dat = open(os.environ.get("FP")).read()
+result = run(dat)
+print("Total        %.3fms" % (1000 * (time.monotonic() - before)))
+print("Result: ", result)


### PR DESCRIPTION
This change mitigates a performance issue happening with the firstEventDuration where the generic aeson decoder induce a noticable overhead.

Fixes #560