### PR TITLE
Add OnCreatedAndCreated query flavor

### DIFF
--- a/haskell/src/Monocle/Backend/Queries.hs
+++ b/haskell/src/Monocle/Backend/Queries.hs
@@ -650,10 +650,7 @@ getNewContributors = do
 
   let getDateLimit constraint =
         BH.QueryRangeQuery $
-          BH.mkRangeQuery
-            ( BH.FieldName (rangeField CreatedAt)
-            )
-            constraint
+          BH.mkRangeQuery (BH.FieldName "created_at") constraint
 
   let beforeBounceQ b = getDateLimit $ BH.RangeDateLt (BH.LessThanD b)
   let afterBounceQ b = getDateLimit $ BH.RangeDateGte (BH.GreaterThanEqD b)
@@ -817,9 +814,10 @@ getReviewStats = do
 
   let reviewStatsCommentCount = Just commentCount
       reviewStatsReviewCount = Just reviewCount
+      withEvents ev = withFlavor (QueryFlavor Author OnCreatedAndCreated) . withFilter ev
 
-  firstComments <- withFilter [documentType ElkChangeCommentedEvent] firstEventOnChanges
-  firstReviews <- withFilter [documentType ElkChangeReviewedEvent] firstEventOnChanges
+  firstComments <- withEvents [documentType ElkChangeCommentedEvent] firstEventOnChanges
+  firstReviews <- withEvents [documentType ElkChangeReviewedEvent] firstEventOnChanges
 
   let reviewStatsCommentDelay = firstEventAverageDuration firstComments
       reviewStatsReviewDelay = firstEventAverageDuration firstReviews

--- a/haskell/src/Monocle/Env.hs
+++ b/haskell/src/Monocle/Env.hs
@@ -133,7 +133,7 @@ withFlavor flavor = local setFlavor
   where
     -- the new flavor replaces the oldFlavor
     setFlavor (QueryEnv query context) =
-      let newQueryGet modifier _oldFlavor = Q.queryGet query modifier (Just flavor)
+      let newQueryGet modifier oldFlavor = Q.queryGet query modifier (Just $ fromMaybe flavor oldFlavor)
        in QueryEnv (query {Q.queryGet = newQueryGet}) context
 
 -- | 'withModified' run a queryM with a modified query

--- a/haskell/test/Spec.hs
+++ b/haskell/test/Spec.hs
@@ -202,7 +202,11 @@ monocleSearchLanguage =
       withFlavor (Q.QueryFlavor Q.Author Q.OnCreatedAndCreated) $ do
         q <- prettyQuery
         let expected = "{\"bool\":{\"filter\":[{\"range\":{\"created_at\":{\"boost\":1,\"gt\":\"2021-01-01T00:00:00Z\"}}},{\"range\":{\"on_created_at\":{\"boost\":1,\"gt\":\"2021-01-01T00:00:00Z\"}}}]}}"
-        liftIO $ assertEqual "simple queryM work" (Just expected) q
+        liftIO $ assertEqual "OnCreatedAndCreated range flavor" (Just expected) q
+        withFlavor (Q.QueryFlavor Q.Author Q.UpdatedAt) $ do
+          q' <- prettyQuery
+          let expected' = "{\"range\":{\"updated_at\":{\"boost\":1,\"gt\":\"2021-01-01T00:00:00Z\"}}}"
+          liftIO $ assertEqual "range flavor reset" (Just expected') q'
 
     testSimpleQueryM :: Assertion
     testSimpleQueryM = mkQueryM "author:alice" $ do


### PR DESCRIPTION
This change enables a new flavor to set both on_created_at and created_at
range bounds. That is useful to compute elapsed time where we need both
bounds to be set to ensure changes and events are in the same time range.