### PR TITLE
[api] Optimize repos and peer strength query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- [api] Peer strengh and repo summary query slowness has been reduced.
+
 ### Upgrade
 
 ## [1.0.0] - 2021-08-17


### PR DESCRIPTION
This change optimizes two queries:

- compute the peer strength based on the provided limit (instead of the first 5000 authors).
- drop the project field for the per repository summary.