### PR TITLE
[api] Simplify the query language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
+- [api] Support for unicode operators and whitespace around non boolean operators in the query language.
+
 ### Fixed
 
 - [api] Peer strengh and repo summary query slowness has been reduced.

--- a/doc/query-language.md
+++ b/doc/query-language.md
@@ -6,7 +6,7 @@ This document introduces the Monocle Query Language standard.
 Example queries:
 
 - `state:open and review_count:0`
-- `(repo : openstack/nova or repo: openstack/neutron) and user_group:qa and updated_at > 2020`
+- `(repo:openstack/nova or repo:openstack/neutron) and user_group:qa and updated_at>2020`
 
 
 # Backus–Naur form
@@ -37,12 +37,10 @@ label-char = %x41-5A / %x61-7A / "_"
 ; operators are skipped so that we can lex 'name:value' in three token
 value-char =
                       ; 21 is '!' and 22 is '"'
-      %x23-25         ; 26 is '&'
-    / %x27            ; 28 is '(' and 29 is ')'
+      %x23-27         ; 28 is '(' and 29 is ')'
     / %x2A-39         ; 3A is ':'
     / %x3B            ; 3C is '<' and 3D is '=' and 3E is '>'
-    / %x3F-7B         ; 7C is '|'
-    / %x7D-10FFFF     ; todo: skip ∧, ∨ and ¬
+    / %x3F-10FFFF
 
 ; Any char excluding double quote
 quoted-char = %x20-21 / %x23-10FFFF
@@ -53,16 +51,12 @@ field = 1*label-char
 value = quoted-value / 1*value-char
 
 ; boolean operator
-and = "and" / "AND" / "∧" / "&&"
-or  = "or"  / "OR"  / "∨" / "||"
-not = "not" / "NOT" / "¬" / "!"
+and = "and" / "AND"
+or  = "or"  / "OR"
+not = "not" / "NOT"
 
 ; field operator
-eq = ":" / "=" / "=="
-gt = ">"
-ge = ">="
-lt = "<"
-le = "<="
+operator = ":" / ">" / ">=" / "<" / "<="
 
 expression =
     ; boolean operator
@@ -70,15 +64,7 @@ expression =
     / expression whsp1 or whsp1 expression
     / expression whsp1 expression ; implicit AND
     / not whsp1 expression
-
-    ; field operator
-    / field whsp eq whsp value
-    / field whsp gt whsp value
-    / field whsp ge whsp value
-    / field whsp lt whsp value
-    / field whsp le whsp value
-
-    ; priority operator
+    / field operator value
     / "(" whsp expression whsp ")"
 ```
 

--- a/haskell/test/Spec.hs
+++ b/haskell/test/Spec.hs
@@ -80,7 +80,7 @@ monocleSearchLanguage =
       testCase
         "Lexer paren"
         ( lexMatch
-            "(a>42 or a = 0) and b: d"
+            "(a>42 or a:0 ) and b:d"
             [ L.OpenParenthesis,
               L.Literal "a",
               L.Greater,
@@ -101,7 +101,7 @@ monocleSearchLanguage =
         (lexMatch "field:\"A value\"" [L.Literal "field", L.Equal, L.Literal "A value"]),
       testCase
         "Lexer unicode"
-        (lexMatch "!field:λr🌈bow" [L.Not, L.Literal "field", L.Equal, L.Literal "λr🌈bow"]),
+        (lexMatch "not field:λr🌈bow" [L.Not, L.Literal "field", L.Equal, L.Literal "λr🌈bow"]),
       testCase
         "Lexer quoted unicode"
         (lexMatch "\"Zuul ▲ user\"" [L.Literal "Zuul ▲ user"]),
@@ -157,19 +157,19 @@ monocleSearchLanguage =
       testCase
         "Query state"
         ( queryMatch
-            "state: abandoned"
+            "state:abandoned"
             "{\"term\":{\"state\":{\"value\":\"CLOSED\"}}}"
         ),
       testCase
         "Query date"
         ( queryMatch
-            "updated_at > 2021 and updated_at < 2021-05"
+            "updated_at>2021 and updated_at<2021-05"
             "{\"bool\":{\"must\":[{\"range\":{\"updated_at\":{\"boost\":1,\"gt\":\"2021-01-01T00:00:00Z\"}}},{\"range\":{\"updated_at\":{\"boost\":1,\"lt\":\"2021-05-01T00:00:00Z\"}}}]}}"
         ),
       testCase
         "Query relative date"
         ( queryMatch
-            "updated_at > now-3weeks"
+            "updated_at>now-3weeks"
             "{\"range\":{\"updated_at\":{\"boost\":1,\"gt\":\"2021-05-10T00:00:00Z\"}}}"
         ),
       testCase

--- a/web/src/components/HelpSearch.res
+++ b/web/src/components/HelpSearch.res
@@ -61,7 +61,7 @@ module Content = {
       <ul>
         <FakeInput value="state:open approved score>42" />
         <FakeInput
-          value="(repo:openstack/nova or repo:openstack/neutron) and group:qa and updated_at > 2020"
+          value="(repo:openstack/nova or repo:openstack/neutron) and group:qa and updated_at>2020"
         />
         <FakeInput value="author_regex:\"Foo B.*\" and not state:open" />
       </ul>


### PR DESCRIPTION
This change simplifies the query language:

- Remove boolean operator symbols (&& or ¬)
- Remove whitespace around non boolean operators