### PR TITLE
[api] Support legacy task data updated_at value format

### DIFF
--- a/haskell/src/Monocle/Backend/Index.hs
+++ b/haskell/src/Monocle/Backend/Index.hs
@@ -378,7 +378,7 @@ toELKTaskData TaskData {..} =
       tdUrl = toText taskDataUrl
       tdTitle = toText taskDataTitle
       -- We might get a maybe Timestamp - do not fail if Nothing
-      tdUpdatedAt = maybe defaultDate T.toUTCTime taskDataUpdatedAt
+      tdUpdatedAt = UTCTimePlus $ maybe defaultDate T.toUTCTime taskDataUpdatedAt
    in ELKTaskData {..}
   where
     defaultDate :: UTCTime =


### PR DESCRIPTION
Previously we were using `%FT%T` instead of the common `%FT%TZ`.
This change adds support for both formats.