### PR TITLE
Use Fedora 35 as base image to benefit GHC 8.10

### DIFF
--- a/.github/workflows/publish-master.yaml
+++ b/.github/workflows/publish-master.yaml
@@ -8,6 +8,14 @@ jobs:
     if: github.repository_owner == 'change-metrics'
     runs-on: ubuntu-latest
     steps:
+      # See https://github.com/actions/virtual-environments/issues/3812 for more information
+      - name: Download Docker with patched seccomp
+        run: |
+          sudo systemctl stop docker containerd
+          sudo apt-get remove --autoremove -y moby-engine moby-cli moby-buildx moby-containerd moby-runc
+          sudo add-apt-repository -y ppa:pascallj/docker.io-clone3
+          sudo apt-get install -y docker.io
+
       - name: Checkout code
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/publish-tag.yaml
+++ b/.github/workflows/publish-tag.yaml
@@ -8,6 +8,14 @@ jobs:
     if: github.repository_owner == 'change-metrics'
     runs-on: ubuntu-latest
     steps:
+      # See https://github.com/actions/virtual-environments/issues/3812 for more information
+      - name: Download Docker with patched seccomp
+        run: |
+          sudo systemctl stop docker containerd
+          sudo apt-get remove --autoremove -y moby-engine moby-cli moby-buildx moby-containerd moby-runc
+          sudo add-apt-repository -y ppa:pascallj/docker.io-clone3
+          sudo apt-get install -y docker.io
+
       - name: Checkout code
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/validate-pr.yaml
+++ b/.github/workflows/validate-pr.yaml
@@ -39,13 +39,17 @@ jobs:
       - name: Test with tox
         run: tox -e py3
 
-      # - name: Validate usefulness of tests
-      #   uses: quality-of-tests/has-useful-tests-action@master
-      #   with:
-      #     run-tests: tox -epy3
   docker:
     runs-on: ubuntu-latest
     steps:
+      # See https://github.com/actions/virtual-environments/issues/3812 for more information
+      - name: Download Docker with patched seccomp
+        run: |
+          sudo systemctl stop docker containerd
+          sudo apt-get remove --autoremove -y moby-engine moby-cli moby-buildx moby-containerd moby-runc
+          sudo add-apt-repository -y ppa:pascallj/docker.io-clone3
+          sudo apt-get install -y docker.io
+
       - name: Checkout code
         uses: actions/checkout@v2
         with:

--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -22,6 +22,6 @@ COPY haskell/ /build
 RUN cabal v2-install -v1 exe:monocle-api exe:macroscope
 
 ################################################################################
-FROM registry.fedoraproject.org/fedora:33
+FROM registry.fedoraproject.org/fedora:35
 
 COPY --from=0 /root/.cabal/bin/monocle-api /root/.cabal/bin/macroscope /bin/


### PR DESCRIPTION
We are hitting:

src/Data/Primitive/Contiguous/Class.hs:11:14: error:
    Unsupported extension: UnliftedNewtypes
    Perhaps you meant ‘UnliftedFFITypes’