### PR TITLE
[api] Wrap the new task data values with optional

### DIFF
--- a/haskell/src/Monocle/Backend/Documents.hs
+++ b/haskell/src/Monocle/Backend/Documents.hs
@@ -133,7 +133,7 @@ instance FromJSON UTCTimePlus where
 
 data ETaskData = ETaskData
   { tdTid :: Text,
-    tdCrawlerName :: Text,
+    tdCrawlerName :: Maybe Text,
     tdTtype :: [Text],
     tdUpdatedAt :: MonocleTime,
     tdChangeUrl :: Text,
@@ -142,7 +142,7 @@ data ETaskData = ETaskData
     tdScore :: Int32,
     tdUrl :: Text,
     tdTitle :: Text,
-    tdPrefix :: Text
+    tdPrefix :: Maybe Text
   }
   deriving (Show, Eq, Generic)
 
@@ -163,7 +163,7 @@ instance From ETaskData SearchPB.TaskData where
         taskDataSeverity = from $ tdSeverity td
         taskDataPriority = from $ tdPriority td
         taskDataScore = from $ tdScore td
-        taskDataPrefix = from $ tdPrefix td
+        taskDataPrefix = from $ fromMaybe "" $ tdPrefix td
      in SearchPB.TaskData {..}
 
 data EChangeState

--- a/haskell/src/Monocle/Backend/Index.hs
+++ b/haskell/src/Monocle/Backend/Index.hs
@@ -326,8 +326,9 @@ getEventType eventTypeM = case eventTypeM of
   Nothing -> error "changeEventType field is mandatory"
 
 toETaskData :: Text -> TaskData -> ETaskData
-toETaskData tdCrawlerName TaskData {..} =
+toETaskData crawlerName TaskData {..} =
   let tdTid = toText taskDataTid
+      tdCrawlerName = Just crawlerName
       tdTtype = toList $ toText <$> taskDataTtype
       tdChangeUrl = toText taskDataChangeUrl
       tdSeverity = toText taskDataSeverity
@@ -335,7 +336,7 @@ toETaskData tdCrawlerName TaskData {..} =
       tdScore = fromInteger $ toInteger taskDataScore
       tdUrl = toText taskDataUrl
       tdTitle = toText taskDataTitle
-      tdPrefix = toText taskDataPrefix
+      tdPrefix = Just $ toText taskDataPrefix
       -- We might get a maybe Timestamp - do not fail if Nothing
       tdUpdatedAt = toMonocleTime $ maybe defaultDate T.toUTCTime taskDataUpdatedAt
    in ETaskData {..}

--- a/haskell/src/Monocle/Backend/Janitor.hs
+++ b/haskell/src/Monocle/Backend/Janitor.hs
@@ -105,7 +105,7 @@ removeTDCrawlerData crawlerName = do
               x -> Just x
             isNotCrawler :: D.ETaskData -> Bool
             isNotCrawler etd
-              | tdCrawlerName etd == crawlerName = False
+              | tdCrawlerName etd == Just crawlerName = False
               | otherwise = True
 
     removeOrphanTaskDatas :: BH.IndexName -> QueryM Int

--- a/haskell/src/Monocle/Backend/Provisioner.hs
+++ b/haskell/src/Monocle/Backend/Provisioner.hs
@@ -148,7 +148,7 @@ fakeTaskPrefix = Faker.Combinators.elements ["rhbz#", "gh#", "lada"]
 fakeETaskData :: Faker.Fake ETaskData
 fakeETaskData = do
   tdTid <- fakeTaskId
-  tdCrawlerName <- Faker.Creature.Dog.name
+  tdCrawlerName <- Just <$> Faker.Creature.Dog.name
   tdTtype <- (: []) <$> Faker.Creature.Dog.sound
   tdUpdatedAt <- toMonocleTime <$> Faker.DateTime.utc
   tdChangeUrl <- pure "no-change"
@@ -157,7 +157,7 @@ fakeETaskData = do
   tdScore <- Faker.Combinators.fromRange (0, 42)
   tdUrl <- fakeUrl tdTid
   tdTitle <- Faker.TvShow.TheExpanse.quotes
-  tdPrefix <- fakeTaskPrefix
+  tdPrefix <- Just <$> fakeTaskPrefix
   pure $ ETaskData {..}
 
 fakeTaskData :: Faker.Fake TaskData

--- a/haskell/src/Monocle/Env.hs
+++ b/haskell/src/Monocle/Env.hs
@@ -298,7 +298,7 @@ eventToText ev = case ev of
   AddingChange crawler changes events ->
     toStrict crawler <> " adding " <> show changes <> " changes with " <> show events <> " events"
   AddingProject crawler organizationName projects ->
-    crawler <> " adding " <> show projects <> " changes for organization" <> organizationName
+    crawler <> " adding " <> show projects <> " changes for organization: " <> organizationName
   UpdatingEntity crawler entity ts ->
     toStrict crawler <> " updating " <> show entity <> " to " <> show ts
   Searching queryType queryText query ->


### PR DESCRIPTION
This change ensure the backend correctly decode existing
task data which does not have the new values.