### PR TITLE
[lentille-gerrit] provide various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - [crawler] Identities aliases are now properly assigned for GitLab and Gerrit author.
+- [crawler] Gerrit - mergeable status not correctly computed.
+- [crawler] Gerrit - ChangeCommentedEvent and ChangeReviewedEvent overlap.
 
 ## [1.2.0] - 2021-10-26
 


### PR DESCRIPTION
- Wrong mergeable status computation
- Collapse between ChangeCommentedEvent/ChangeReviewedEvent

Also mimic the previous (legacy Gerrit crawler) doc Id naming.