### PR TITLE
[backend] fix an issue to properly resolve idents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 ### Removed
 ### Fixed
 
+## [1.2.1]
+
+### Fixed
+
+- [crawler] Identities aliases are now properly assigned for GitLab and Gerrit author.
+
 ## [1.2.0] - 2021-10-26
 
 Notice that the crawler and api containers are based on a recent version of Fedora 35 that

--- a/haskell/src/Lentille/GitLab/MergeRequests.hs
+++ b/haskell/src/Lentille/GitLab/MergeRequests.hs
@@ -137,12 +137,12 @@ streamMergeRequests client getIdentIdCb untilDate project =
     isDateOlderThan :: UTCTime -> UTCTime -> Bool
     isDateOlderThan t1 t2 = diffUTCTime t1 t2 < 0
 
-    transformResponse' = transformResponse (host client) (Just getIdentIdCb)
+    transformResponse' = transformResponse (host client) getIdentIdCb
 
 transformResponse ::
   Text ->
   -- A callback to get Ident ID from an alias
-  Maybe (Text -> Maybe Text) ->
+  (Text -> Maybe Text) ->
   GetProjectMergeRequests ->
   (PageInfo, Maybe RateLimit, [Text], [(Change, [ChangeEvent])])
 transformResponse host getIdentIdCB result =

--- a/haskell/src/Macroscope/Main.hs
+++ b/haskell/src/Macroscope/Main.hs
@@ -7,7 +7,7 @@ import qualified Data.Text as T
 import Lentille
 import Lentille.Bugzilla (BugzillaSession, MonadBZ, getApikey, getBZData, getBugzillaSession)
 import Lentille.Gerrit (MonadGerrit (..))
-import qualified Lentille.Gerrit as GerritCrawler (GerritEnv, getChangesStream, getGerritEnv, getProjectsStream)
+import qualified Lentille.Gerrit as GerritCrawler (GerritEnv (..), getChangesStream, getProjectsStream)
 import Lentille.GitHub.Issues (streamLinkedIssue)
 import Lentille.GitLab.Group (streamGroupProjects)
 import Lentille.GitLab.MergeRequests (streamMergeRequests)
@@ -92,7 +92,7 @@ runMacroscope' verbose confPath interval client = do
               pure $ Just (login, passwd)
             Nothing -> pure Nothing
           gClient <- getGerritClient gerrit_url auth
-          let gerritEnv = GerritCrawler.getGerritEnv gClient gerrit_prefix $ Just getIdentByAliasCB
+          let gerritEnv = GerritCrawler.GerritEnv gClient gerrit_prefix getIdentByAliasCB
           pure $
             [gerritREProjectsCrawler gerritEnv | maybe False (not . null . gerritRegexProjects) gerrit_repositories]
               <> [gerritChangesCrawler gerritEnv | isJust gerrit_repositories]

--- a/haskell/src/Monocle/Api/Config.hs
+++ b/haskell/src/Monocle/Api/Config.hs
@@ -294,20 +294,20 @@ getTenantProjectsNames index = map getName $ fromMaybe [] $ projects index
 
 -- >>> :{
 --  let
---    index = emptyTenant "test" [createIdent "alice" ["opendev.org/Alice Doe/12345", "github.com/alice89"] []]
---  in getIdentByAlias index "github.com/ghost"
+--    index = emptyTenant "test" [createIdent "bob" [], createIdent "alice" ["opendev.org/Alice Doe/12345", "github.com/alice89"] []]
+--  in [getIdentByAlias index "github.com/ghost", getIdentByAlias index "github.com/alice89"]
 -- :}
--- Nothing
+-- [Nothing,Just "alice"]
 getIdentByAlias :: Index -> Text -> Maybe Text
 getIdentByAlias Index {..} alias = getIdentByAliasFromIdents alias =<< idents
 
 getIdentByAliasFromIdents :: Text -> [Ident] -> Maybe Text
-getIdentByAliasFromIdents alias idents' = case isMatched <$> idents' of
-  [] -> Nothing
-  x : _ -> x
+getIdentByAliasFromIdents alias idents' = case find isMatched idents' of
+  Nothing -> Nothing
+  Just Ident {..} -> Just ident
   where
-    isMatched :: Ident -> Maybe Text
-    isMatched Ident {..} = if alias `elem` aliases then Just ident else Nothing
+    isMatched :: Ident -> Bool
+    isMatched Ident {..} = alias `elem` aliases
 
 resolveEnv :: MonadIO m => Index -> m Index
 resolveEnv = liftIO . mapMOf crawlersApiKeyLens getEnv'


### PR DESCRIPTION
This change fixes the getIdentByAliasFromIdents implementation to properly return found aliases. The function was working only if the first alias matched instead of the first match.

This change also includes minor refactors I performed during the investigation.