### PR TITLE
[backend] Move all the CLI code to a single module

### DIFF
--- a/haskell/app/Api.hs
+++ b/haskell/app/Api.hs
@@ -1,57 +1,7 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-
 module Main (main) where
 
-import Env
-import qualified Monocle.Api
-import Options.Generic
-import Relude
-
----------------------------------------------------------------
--- CLI available environment variables
----------------------------------------------------------------
-
-data CliEnv = CliEnv
-  { config :: String,
-    elastic_conn :: String
-  }
-
-cliEnv :: IO CliEnv
-cliEnv =
-  Env.parse (header "monocle-api available environement variables") $
-    CliEnv <$> var (str) "CONFIG" (help "The Monocle configuration" <> def "/etc/monocle/config.yaml" <> helpDef show)
-      <*> var (str) "ELASTIC_CONN" (help "The Elasticsearch endpoint" <> def "elastic:9200")
-
----------------------------------------------------------------
--- CLI arguments parser
----------------------------------------------------------------
-
-data CLIOptions w = CLIOption
-  { port :: w ::: Maybe Int <?> "The API port to listen to, default to 9898"
-  }
-  deriving stock (Generic)
-
-instance ParseRecord (CLIOptions Wrapped) where
-  parseRecord = parseRecordWithModifiers lispCaseModifiers
-
----------------------------------------------------------------
--- CLI functions
----------------------------------------------------------------
-
-getURL :: String -> Text
-getURL url =
-  let hasScheme = isPrefixOf "http://" url || isPrefixOf "https://" url
-      url' = if hasScheme then url else "http://" <> url
-   in toText url'
+import qualified CLI
+import Prelude (IO)
 
 main :: IO ()
-main = do
-  -- Fetch environement variables
-  CliEnv {config, elastic_conn} <- cliEnv
-  -- Run arguments parser
-  args <- unwrapRecord "Monocle API"
-  -- Run the Monocle API
-  Monocle.Api.run (fromMaybe 8989 (port args)) (getURL elastic_conn) config
+main = CLI.mainApi

--- a/haskell/app/LentilleStandalone.hs
+++ b/haskell/app/LentilleStandalone.hs
@@ -1,50 +1,7 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# OPTIONS_GHC -Wno-partial-fields #-}
-
 module Main (main) where
 
-import qualified Lentille.Gerrit as G
-import Monocle.Prelude
-import Monocle.Search.Query (parseDateValue)
-import Options.Generic
-import qualified Streaming.Prelude as S
-
-data Lentille
-  = GerritChange {url :: Text, change :: Int}
-  | GerritProjects {url :: Text, query :: Text}
-  | GerritChanges {url :: Text, project :: Text, since :: Text, limit :: Maybe Int}
-  deriving stock (Generic)
-
-instance ParseRecord Lentille where
-  parseRecord = parseRecordWithModifiers lispCaseModifiers
-
-dump :: (MonadIO m, ToJSON a) => Maybe Int -> Stream (Of a) m () -> m ()
-dump limitM stream = do
-  xs <- S.toList_ $ brk $ stream
-  liftIO . putBSLn . from . encodePrettyWithSpace 2 $ xs
-  where
-    brk = case limitM of
-      Nothing -> id
-      Just limit -> S.take limit
+import qualified CLI
+import Prelude (IO)
 
 main :: IO ()
-main = do
-  args <- getRecord "Lentille runner"
-  case args of
-    GerritChange url change -> do
-      env <- getGerritEnv url
-      dump Nothing $ G.streamChange env [G.ChangeId $ show change]
-    GerritProjects url query -> do
-      env <- getGerritEnv url
-      dump Nothing $ G.streamProject env $ G.Regexp query
-    GerritChanges url project since limit -> do
-      env <- getGerritEnv url
-      dump limit $ G.streamChange env [G.Project project, G.After (toSince since)]
-  where
-    toSince txt = case Monocle.Search.Query.parseDateValue txt of
-      Just x -> x
-      Nothing -> error $ "Invalid date: " <> show txt
-    getGerritEnv url = do
-      client <- G.getGerritClient url Nothing
-      pure $ G.GerritEnv client Nothing (const Nothing)
+main = CLI.mainLentille

--- a/haskell/app/Macroscope.hs
+++ b/haskell/app/Macroscope.hs
@@ -1,29 +1,7 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleInstances #-}
-
 module Main (main) where
 
-import Macroscope.Main (runMacroscope)
-import Monocle.Client (withClient)
-import Options.Generic
-import Relude
-
-data Macroscope w = Macroscope
-  { monocleUrl :: w ::: Maybe Text <?> "The monocle API",
-    port :: w ::: Int <!> "9001" <?> "Health check port",
-    config :: w ::: Maybe FilePath <?> "The monocle configuration"
-  }
-  deriving stock (Generic)
-
-instance ParseRecord (Macroscope Wrapped) where
-  parseRecord = parseRecordWithModifiers lispCaseModifiers
+import qualified CLI
+import Prelude (IO)
 
 main :: IO ()
-main = do
-  args <- unwrapRecord "Macroscope lentille runner"
-  config' <- fromMaybe (error "--config or CONFIG env is required") <$> lookupEnv "CONFIG"
-  withClient (fromMaybe "http://web:8080" $ monocleUrl args) Nothing $ \client ->
-    runMacroscope
-      (port args)
-      (fromMaybe config' $ config args)
-      client
+main = CLI.mainMacroscope

--- a/haskell/monocle.cabal
+++ b/haskell/monocle.cabal
@@ -92,9 +92,7 @@ common codegen
 
 common cli-options
   hs-source-dirs:      app
-  build-depends:       optparse-generic           < 1.5
-                     , monocle
-                     , relude                     > 1.0 && < 1.1
+  build-depends:       base, monocle
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
 
 library
@@ -117,6 +115,7 @@ library
                      , dhall-yaml                 ^>= 1.2
                      , directory
                      , either                     ^>= 5
+                     , envparse                   < 0.4.2
                      , exceptions                 < 0.11
                      , fakedata                   >= 1.0
                      , fast-logger
@@ -135,6 +134,7 @@ library
                      , mtl
                      , network                    < 4
                      , network-uri                < 2.6.5
+                     , optparse-generic           < 1.5
                      , parser-combinators         < 1.3
                      , prometheus-client          ^>= 1.0
                      , prometheus-metrics-ghc     ^>= 1.0
@@ -168,6 +168,7 @@ library
   exposed-modules:     Monocle.Prelude
                      , Monocle.Env
                      , Monocle.Class
+                     , CLI
 
                      -- monocle api
                      , Monocle.Api
@@ -232,12 +233,7 @@ library
 
 executable monocle-api
   import:              common-options, cli-options
-  hs-source-dirs:      app
   main-is:             Api.hs
-  build-depends:       base
-                     , monocle
-                     , relude
-                     , envparse                   < 0.4.2
 
 executable macroscope
   import:              common-options, cli-options
@@ -246,7 +242,6 @@ executable macroscope
 executable lentille
   import:              common-options, cli-options
   main-is:             LentilleStandalone.hs
-  build-depends:       streaming
 
 benchmark json-decode
   import:              common-options

--- a/haskell/src/CLI.hs
+++ b/haskell/src/CLI.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# OPTIONS_GHC -Wno-partial-fields #-}
+
+-- | The CLI entrpoints
+module CLI (mainApi, mainMacroscope, mainLentille) where
+
+import Env
+import qualified Lentille.Gerrit as G
+import Macroscope.Main (runMacroscope)
+import qualified Monocle.Api
+import Monocle.Client (withClient)
+import Monocle.Prelude
+import Monocle.Search.Query (parseDateValue)
+import Options.Generic
+import qualified Streaming.Prelude as S
+
+---------------------------------------------------------------
+-- API cli
+---------------------------------------------------------------
+
+data CliEnv = CliEnv
+  { config :: String,
+    elastic_conn :: String
+  }
+
+cliEnv :: IO CliEnv
+cliEnv =
+  Env.parse (header "monocle-api available environement variables") $
+    CliEnv <$> var (str) "CONFIG" (help "The Monocle configuration" <> def "/etc/monocle/config.yaml" <> helpDef show)
+      <*> var (str) "ELASTIC_CONN" (help "The Elasticsearch endpoint" <> def "elastic:9200")
+
+data CLIOptions w = CLIOption
+  { port :: w ::: Maybe Int <?> "The API port to listen to, default to 9898"
+  }
+  deriving stock (Generic)
+
+instance ParseRecord (CLIOptions Wrapped) where
+  parseRecord = parseRecordWithModifiers lispCaseModifiers
+
+getURL :: String -> Text
+getURL url =
+  let hasScheme = isPrefixOf "http://" url || isPrefixOf "https://" url
+      url' = if hasScheme then url else "http://" <> url
+   in toText url'
+
+mainApi :: IO ()
+mainApi = do
+  -- Fetch environement variables
+  CliEnv {config, elastic_conn} <- cliEnv
+  -- Run arguments parser
+  CLIOption port' <- unwrapRecord "Monocle API"
+  -- Run the Monocle API
+  Monocle.Api.run (fromMaybe 8989 port') (getURL elastic_conn) config
+
+---------------------------------------------------------------
+-- Macroscope cli
+---------------------------------------------------------------
+
+data Macroscope w = Macroscope
+  { monocleUrl :: w ::: Maybe Text <?> "The monocle API",
+    port :: w ::: Int <!> "9001" <?> "Health check port",
+    config :: w ::: Maybe FilePath <?> "The monocle configuration"
+  }
+  deriving stock (Generic)
+
+instance ParseRecord (Macroscope Wrapped) where
+  parseRecord = parseRecordWithModifiers lispCaseModifiers
+
+mainMacroscope :: IO ()
+mainMacroscope = do
+  Macroscope monocleUrl' port' config'' <- unwrapRecord "Macroscope lentille runner"
+  config' <- fromMaybe (error "--config or CONFIG env is required") <$> lookupEnv "CONFIG"
+  withClient (fromMaybe "http://web:8080" monocleUrl') Nothing $ \client ->
+    runMacroscope
+      port'
+      (fromMaybe config' config'')
+      client
+
+---------------------------------------------------------------
+-- Lentille cli
+---------------------------------------------------------------
+
+data Lentille
+  = GerritChange {url :: Text, change :: Int}
+  | GerritProjects {url :: Text, query :: Text}
+  | GerritChanges {url :: Text, project :: Text, since :: Text, limit :: Maybe Int}
+  deriving stock (Generic)
+
+instance ParseRecord Lentille where
+  parseRecord = parseRecordWithModifiers lispCaseModifiers
+
+dump :: (MonadIO m, ToJSON a) => Maybe Int -> Stream (Of a) m () -> m ()
+dump limitM stream = do
+  xs <- S.toList_ $ brk $ stream
+  liftIO . putBSLn . from . encodePrettyWithSpace 2 $ xs
+  where
+    brk = case limitM of
+      Nothing -> id
+      Just limit -> S.take limit
+
+mainLentille :: IO ()
+mainLentille = do
+  args <- getRecord "Lentille runner"
+  case args of
+    GerritChange url change -> do
+      env <- getGerritEnv url
+      dump Nothing $ G.streamChange env [G.ChangeId $ show change]
+    GerritProjects url query -> do
+      env <- getGerritEnv url
+      dump Nothing $ G.streamProject env $ G.Regexp query
+    GerritChanges url project since limit -> do
+      env <- getGerritEnv url
+      dump limit $ G.streamChange env [G.Project project, G.After (toSince since)]
+  where
+    toSince txt = case Monocle.Search.Query.parseDateValue txt of
+      Just x -> x
+      Nothing -> error $ "Invalid date: " <> show txt
+    getGerritEnv url = do
+      client <- G.getGerritClient url Nothing
+      pure $ G.GerritEnv client Nothing (const Nothing)


### PR DESCRIPTION
This change finishes the migration to a god library where
the common code is now part of the CLI module.

The goal being that ghcid automatically validate the new module.