### PR TITLE
[compose] fix api health check test command

### DIFF
--- a/docker-compose.dhall
+++ b/docker-compose.dhall
@@ -118,7 +118,7 @@ let createApiService =
         let service =
               { healthcheck = Some
                   ( mkHealthCheck
-                      "python -c \"import requests,sys; r=requests.post('http://localhost:9898/api/2/health', json={}); print(r.text); sys.exit(1) if r.status_code!=200 else sys.exit(0)\""
+                      "curl --silent --fail localhost:9898/health || exit 1"
                   )
               , depends_on = Some [ "elastic" ]
               , command = Some

--- a/docker-compose.yml.dev
+++ b/docker-compose.yml.dev
@@ -14,7 +14,7 @@ services:
       ELASTIC_CONN: elastic:9200
     healthcheck:
       retries: 6
-      test: "python -c \"import requests,sys; r=requests.post('http://localhost:9898/api/2/health', json={}); print(r.text); sys.exit(1) if r.status_code!=200 else sys.exit(0)\""
+      test: "curl --silent --fail localhost:9898/health || exit 1"
       timeout: "60s"
     ports:
       - "${MONOCLE_API_ADDR:-0.0.0.0}:${MONOCLE_API_PORT:-9898}:9898"

--- a/docker-compose.yml.img
+++ b/docker-compose.yml.img
@@ -11,7 +11,7 @@ services:
       - 9898
     healthcheck:
       retries: 6
-      test: "python -c \"import requests,sys; r=requests.post('http://localhost:9898/api/2/health', json={}); print(r.text); sys.exit(1) if r.status_code!=200 else sys.exit(0)\""
+      test: "curl --silent --fail localhost:9898/health || exit 1"
       timeout: "60s"
     image: "quay.io/change-metrics/monocle_api:${MONOCLE_VERSION:-latest}"
     restart: unless-stopped


### PR DESCRIPTION
Previous command failed and resulted in unheathly state.
"Output": "/bin/sh: line 1: python: command not found\n"