### PR TITLE
[backend] Add crawler metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,13 +519,14 @@ To setup the monitoring:
 export API_TARGET=localhost:9879
 export CRAWLER_TARGET=localhost:9001
 mkdir -p /srv/prometheus
-podman create --network host -v /srv/prometheus:/data:Z -e API_TARGET=${API_TARGET} -e CRAWLER_TARGET=${CRAWLER_TARGET} --name monocle-prometheus quay.io/change-metrics/monocle-prometheus:latest
+podman create --network host -v /srv/prometheus:/var/lib/prometheus:Z -e API_TARGET=${API_TARGET} -e CRAWLER_TARGET=${CRAWLER_TARGET} --name monocle-prometheus quay.io/change-metrics/monocle-prometheus:latest
 ```
 
-2. Create the grafana service
+2. Create the grafana service (on the prometheus host)
 
 ```ShellSession
-podman create --network host --name monocle-grafana quay.io/change-metrics/monocle-grafana:latest
+mkdir -p /srv/grafana
+podman create --network host -v /srv/grafana:/var/lib/grafana:Z -e ADMIN_PASSWORD=secret --name monocle-grafana quay.io/change-metrics/monocle-grafana:latest
 ```
 
 3. Starts the services with systemd
@@ -536,6 +537,8 @@ for service in prometheus grafana; do podman generate systemd -n monocle-$servic
 systemctl --user daemon-reload
 for service in prometheus grafana; do systemctl --user start monocle-$service; done
 ```
+
+4. Check metrics with grafana dashboard at http://localhost:19030/
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -508,6 +508,35 @@ Some legacy component are still required until they are migrated to the new Open
 
 5. a crawler service to index github and gerrit changes.
 
+
+## Monistoring
+
+To setup the monitoring:
+
+1. Create the prometheus service by providing the API and CRAWLER location
+
+```ShellSession
+export API_TARGET=localhost:9879
+export CRAWLER_TARGET=localhost:9001
+mkdir -p /srv/prometheus
+podman create --network host -v /srv/prometheus:/data:Z -e API_TARGET=${API_TARGET} -e CRAWLER_TARGET=${CRAWLER_TARGET} --name monocle-prometheus quay.io/change-metrics/monocle-prometheus:latest
+```
+
+2. Create the grafana service
+
+```ShellSession
+podman create --network host --name monocle-grafana quay.io/change-metrics/monocle-grafana:latest
+```
+
+3. Starts the services with systemd
+
+```ShellSession
+mkdir -p ~/.config/systemd/user/
+for service in prometheus grafana; do podman generate systemd -n monocle-$service > ~/.config/systemd/user/monocle-$service.service; done
+systemctl --user daemon-reload
+for service in prometheus grafana; do systemctl --user start monocle-$service; done
+```
+
 ## Contributing
 
 Follow [our contributing guide](CONTRIBUTING.md).

--- a/conf/grafana-dashboard.dhall
+++ b/conf/grafana-dashboard.dhall
@@ -1,5 +1,6 @@
 let Grafana =
-      https://raw.githubusercontent.com/weeezes/dhall-grafana/f78d2887939dcb555a47a4b85a91a3d6b38ec2ea/package.dhall sha256:a0e1b5432090944fa671efce0085c6049019ae0d00ca289c268b4528d1cd39af
+        env:DHALL_GRAFANA
+      ? https://raw.githubusercontent.com/weeezes/dhall-grafana/f78d2887939dcb555a47a4b85a91a3d6b38ec2ea/package.dhall sha256:a0e1b5432090944fa671efce0085c6049019ae0d00ca289c268b4528d1cd39af
 
 let datasource = Some (env:GRAFANA_DATASOURCE as Text ? "Prometheus")
 

--- a/haskell/src/Lentille.hs
+++ b/haskell/src/Lentille.hs
@@ -41,7 +41,7 @@ import qualified Network.HTTP.Client as HTTP
 newtype LentilleM a = LentilleM {unLentille :: ReaderT CrawlerEnv IO a}
   deriving newtype (Functor, Applicative, Monad, MonadIO, MonadThrow, MonadCatch, MonadMask)
   deriving newtype (MonadReader CrawlerEnv)
-  deriving newtype (MonadUnliftIO)
+  deriving newtype (MonadUnliftIO, MonadMonitor)
 
 data CrawlerEnv = CrawlerEnv
   { crawlerClient :: MonocleClient,

--- a/haskell/src/Lentille/Bugzilla.hs
+++ b/haskell/src/Lentille/Bugzilla.hs
@@ -181,7 +181,7 @@ getBZData bzSession sinceTS productName = go 0
       -- Retrieve rhbz
       bugs <- lift $ do
         mLog $ Log Unspecified (LogGetBugs sinceTS offset limit)
-        retry . doGet $ offset
+        retry "bz" . doGet $ offset
       -- Create a flat stream of tracker data
       S.each (concatMap toTaskData bugs)
       -- Keep on retrieving the rest

--- a/haskell/src/Lentille/GraphQL.hs
+++ b/haskell/src/Lentille/GraphQL.hs
@@ -28,11 +28,12 @@ data GraphClient = GraphClient
   { manager :: HTTP.Manager,
     url :: Text,
     host :: Text,
-    token :: Secret
+    token :: Secret,
+    crawler :: Text
   }
 
-newGraphClient :: MonadGraphQL m => Text -> Secret -> m GraphClient
-newGraphClient url token = do
+newGraphClient :: MonadGraphQL m => "crawler" ::: Text -> Text -> Secret -> m GraphClient
+newGraphClient crawler url token = do
   manager <- newManager
   let host =
         maybe
@@ -64,7 +65,7 @@ doGraphRequest GraphClient {..} jsonBody = do
           }
 
   -- Do the request
-  response <- lift $ httpRequest request manager
+  response <- lift $ retry crawler $ httpRequest request manager
 
   -- Record the event
   tell [(request, response)]

--- a/haskell/src/Macroscope/Worker.hs
+++ b/haskell/src/Macroscope/Worker.hs
@@ -150,7 +150,7 @@ runStream apiKey indexName crawlerName documentStream = drainEntities (0 :: Word
       wLog $ LogMacroRequestOldestEntity lc (streamType documentStream)
 
       -- Query the monocle api for the oldest entity to be updated.
-      entityM <- retry $ getOldestEntity offset
+      entityM <- retry "monocle" $ getOldestEntity offset
       case entityM of
         Nothing -> wLog $ LogMacroNoOldestEnity lc
         Just entity -> do
@@ -165,12 +165,12 @@ runStream apiKey indexName crawlerName documentStream = drainEntities (0 :: Word
               postResult <-
                 process
                   processLogFunc
-                  (retry . addDoc entity)
+                  (retry "monocle" . addDoc entity)
                   (getStream entity)
               case foldr collectPostFailure [] postResult of
                 [] -> do
                   -- Post the commit date
-                  res <- retry $ commitTimestamp entity startTime
+                  res <- retry "monocle" $ commitTimestamp entity startTime
                   if not res
                     then wLog $ LogMacroCommitFailed lc
                     else do

--- a/haskell/src/Monocle/Api.hs
+++ b/haskell/src/Monocle/Api.hs
@@ -56,7 +56,7 @@ run' port url configFile glLogger = do
 
   bhEnv <- mkEnv url
   let aEnv = Env {..}
-  retry $ liftIO $ traverse_ (\tenant -> runQueryM' bhEnv tenant I.ensureIndex) workspaces
+  retry "elastic" $ liftIO $ traverse_ (\tenant -> runQueryM' bhEnv tenant I.ensureIndex) workspaces
   liftIO $
     withStdoutLogger $ \aplogger -> do
       let settings = Warp.setPort port $ Warp.setLogger aplogger Warp.defaultSettings

--- a/haskell/src/Monocle/Api/Config.hs
+++ b/haskell/src/Monocle/Api/Config.hs
@@ -260,6 +260,9 @@ getCrawlerTaskData Crawler {..} = case provider of
   BugzillaProvider Bugzilla {..} -> fromMaybe [] bugzilla_products
   _anyOtherProvider -> []
 
+getCrawlerName :: Crawler -> Text
+getCrawlerName Crawler {..} = name
+
 emptyTenant :: Text -> [Ident] -> Index
 emptyTenant name idents' =
   let crawlers_api_key = Nothing

--- a/haskell/src/Monocle/Api/Server.hs
+++ b/haskell/src/Monocle/Api/Server.hs
@@ -406,6 +406,7 @@ searchCheck :: SearchPB.CheckRequest -> AppM SearchPB.CheckResponse
 searchCheck request = do
   let SearchPB.CheckRequest {..} = request
 
+  incCounter monocleQueryCheckCounter
   requestE <- validateSearchRequest checkRequestIndex checkRequestQuery checkRequestUsername
 
   pure $
@@ -421,6 +422,7 @@ searchQuery :: QueryRequest -> AppM QueryResponse
 searchQuery request = do
   let SearchPB.QueryRequest {..} = request
 
+  incCounter monocleQueryCounter
   requestE <- validateSearchRequest queryRequestIndex queryRequestQuery queryRequestUsername
 
   case requestE of

--- a/haskell/src/Monocle/Env.hs
+++ b/haskell/src/Monocle/Env.hs
@@ -33,6 +33,9 @@ newtype AppM a = AppM {unApp :: ReaderT AppEnv Servant.Handler a}
   deriving newtype (Functor, Applicative, Monad, MonadIO, MonadThrow)
   deriving newtype (MonadReader AppEnv)
 
+instance MonadMonitor AppM where
+  doIO = liftIO
+
 -- | We can derive a MonadBH from AppM, we just needs to tell 'getBHEnv' where is BHEnv
 instance BH.MonadBH AppM where
   getBHEnv = asks (bhEnv . aEnv)
@@ -73,7 +76,7 @@ data QueryEnv = QueryEnv
 newtype QueryM a = QueryM {unTenant :: ReaderT QueryEnv IO a}
   deriving newtype (Functor, Applicative, Monad, MonadIO, MonadFail, MonadThrow)
   deriving newtype (MonadReader QueryEnv)
-  deriving newtype (MonadUnliftIO)
+  deriving newtype (MonadUnliftIO, MonadMonitor)
 
 -- | We can derive a MonadBH from QueryM, we just needs to read the BHEnv from the tEnv
 instance BH.MonadBH QueryM where

--- a/haskell/src/Monocle/Prelude.hs
+++ b/haskell/src/Monocle/Prelude.hs
@@ -127,7 +127,7 @@ module Monocle.Prelude
     fromPBEnum,
 
     -- * prometheus re-exports
-    Prometheus.MonadMonitor,
+    Prometheus.MonadMonitor (..),
     Prometheus.withLabel,
     Prometheus.incCounter,
     Prometheus.counter,
@@ -143,6 +143,8 @@ module Monocle.Prelude
     incrementCounter,
     httpRequestCounter,
     httpFailureCounter,
+    monocleQueryCheckCounter,
+    monocleQueryCounter,
   )
 where
 
@@ -195,6 +197,16 @@ incrementCounter x l = withLabel x l incCounter
 
 -------------------------------------------------------------------------------
 -- Global metrics
+{-# NOINLINE monocleQueryCheckCounter #-}
+monocleQueryCheckCounter :: Prometheus.Counter
+monocleQueryCheckCounter =
+  unsafePerformIO $ promRegister $ Prometheus.counter (Info "query_check" "")
+
+{-# NOINLINE monocleQueryCounter #-}
+monocleQueryCounter :: Prometheus.Counter
+monocleQueryCounter =
+  unsafePerformIO $ promRegister $ Prometheus.counter (Info "query" "")
+
 {-# NOINLINE httpRequestCounter #-}
 httpRequestCounter :: CounterLabel
 httpRequestCounter =

--- a/nix/README.md
+++ b/nix/README.md
@@ -17,10 +17,17 @@ Starts the hoogle search engine:
 nix-shell --command "hoogle server -p 8080 --local --haskell"
 ```
 
+Build the project:
+
+```
+export MONOCLE_COMMIT=$(git show HEAD --format="format:%H" -q)
+$(nix-build --attr monocle)/bin/monocle-api --help
+podman load < $(nix-build --attr containerBackend)
+```
+
 Build the monitoring containers:
 
 ```ShellSession
-podman load < $(nix-build --attr containerBackend)
 podman load < $(nix-build --attr containerPrometheus)
 podman load < $(nix-build --attr containerGrafana)
 ```
@@ -28,13 +35,6 @@ podman load < $(nix-build --attr containerGrafana)
 Test the containers:
 
 ```ShellSession
-podman run --network host -v /srv/prometheus:/data:Z -e API_TARGET=localhost:19875 --rm quay.io/change-metrics/monocle-prometheus:latest
+podman run --network host -v prom-data:/var/lib/prometheus:Z -e API_TARGET=localhost:19875 --rm quay.io/change-metrics/monocle-prometheus:latest
 podman run -it --rm --network host quay.io/change-metrics/monocle-grafana:latest
-```
-
-Build the project:
-
-```
-export PODENV_COMMIT=$(git show HEAD --format="format:%H" -q)
-$(nix-build --attr monocle)/bin/monocle-api --help
 ```

--- a/nix/README.md
+++ b/nix/README.md
@@ -16,3 +16,17 @@ Starts the hoogle search engine:
 ```ShellSession
 nix-shell --command "hoogle server -p 8080 --local --haskell"
 ```
+
+Build the monitoring containers:
+
+```ShellSession
+podman load < $(nix-build --attr containerPrometheus)
+podman load < $(nix-build --attr containerGrafana)
+```
+
+Test the containers:
+
+```ShellSession
+podman run --network host -v /srv/prometheus:/data:Z -e API_TARGET=localhost:19875 --rm quay.io/change-metrics/monocle-prometheus:latest
+podman run -it --rm --network host quay.io/change-metrics/monocle-grafana:latest
+```

--- a/nix/README.md
+++ b/nix/README.md
@@ -20,6 +20,7 @@ nix-shell --command "hoogle server -p 8080 --local --haskell"
 Build the monitoring containers:
 
 ```ShellSession
+podman load < $(nix-build --attr containerBackend)
 podman load < $(nix-build --attr containerPrometheus)
 podman load < $(nix-build --attr containerGrafana)
 ```
@@ -29,4 +30,11 @@ Test the containers:
 ```ShellSession
 podman run --network host -v /srv/prometheus:/data:Z -e API_TARGET=localhost:19875 --rm quay.io/change-metrics/monocle-prometheus:latest
 podman run -it --rm --network host quay.io/change-metrics/monocle-grafana:latest
+```
+
+Build the project:
+
+```
+export PODENV_COMMIT=$(git show HEAD --format="format:%H" -q)
+$(nix-build --attr monocle)/bin/monocle-api --help
 ```

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -564,7 +564,6 @@ in rec {
   # containers
   containerPrometheus = promContainer;
   containerGrafana = grafanaContainer;
-  test = grafanaConfig;
 
   services = pkgs.stdenv.mkDerivation {
     name = "monocle-services";


### PR DESCRIPTION
This PR enables basic http request count metrics.

This PR also improves the nix packages of prometheus and grafana to provide ready to use container image to monitor the backend performance.