### PR TITLE
[api] fixes csWorkspaceStatus being empty at startup

### DIFF
--- a/haskell/src/Monocle/Api/Config.hs
+++ b/haskell/src/Monocle/Api/Config.hs
@@ -179,7 +179,7 @@ reloadConfig fp = do
 
   -- Create the reload action
   tsRef <- newMVar (configTS, config)
-  wsRef <- newMVar mempty
+  wsRef <- newMVar $ mkWorkspaceStatus config
   pure (modifyMVar tsRef (reload wsRef))
   where
     reload wsRef mvar@(prevConfigTS, prevConfig) = do

--- a/haskell/src/Monocle/Api/Server.hs
+++ b/haskell/src/Monocle/Api/Server.hs
@@ -45,7 +45,7 @@ updateIndex index wsRef = runEmptyQueryM index $ modifyMVar_ wsRef doUpdateIfNee
       Just Config.NeedRefresh -> do
         refreshIndex
         pure $ Map.insert (Config.getWorkspaceName index) Config.Ready ws
-      Nothing -> error $ "Unknown workspace: " <> show index
+      Nothing -> error $ "Unknown workspace: " <> show (Config.getWorkspaceName index)
 
     refreshIndex :: QueryM ()
     refreshIndex = do


### PR DESCRIPTION
This fixes an issue where macroscope cannot process as the Map is
empty and resulting in error "Unknown workspace".