### PR TITLE
[backend] Wait for the crawler monitoring server to enable REPL reload

### DIFF
--- a/haskell/src/Monocle/Prelude.hs
+++ b/haskell/src/Monocle/Prelude.hs
@@ -37,6 +37,8 @@ module Monocle.Prelude
     MonadUnliftIO,
     modifyMVar,
     modifyMVar_,
+    withAsync,
+    cancel,
 
     -- * mmoprh
     hoist,
@@ -183,6 +185,7 @@ import qualified Streaming.Prelude as S
 import System.Environment (setEnv)
 import System.IO.Unsafe (unsafePerformIO)
 import Test.Tasty.HUnit
+import UnliftIO.Async (cancel, withAsync)
 import UnliftIO.MVar (modifyMVar, modifyMVar_)
 import Witch hiding (over)
 


### PR DESCRIPTION
This change prevents loosing track of the monitoring service so that
it the macroscope can be safely reloaded from the REPL.