### PR TITLE
[backend] Use an unified CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ All notable changes to this project will be documented in this file.
 - [web] Search field moved out of the top menu into a Patternfly PageSection.
 
 ### Removed
+
+- [baclend] The `monocle-api` and `macroscope` CLI have been merged into a single `monocle` tool.
+
 ### Fixed
 
 ## [1.2.1] - 2021-10-28

--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -22,9 +22,9 @@ ARG MONOCLE_COMMIT
 
 # Build project
 COPY haskell/ /build
-RUN cabal v2-install -v1 exe:monocle-api exe:macroscope
+RUN cabal v2-install -v1 exe:monocle
 
 ################################################################################
 FROM registry.fedoraproject.org/fedora:35
 
-COPY --from=0 /root/.cabal/bin/monocle-api /root/.cabal/bin/macroscope /bin/
+COPY --from=0 /root/.cabal/bin/monocle /bin/

--- a/deployment/api-deployment.yaml
+++ b/deployment/api-deployment.yaml
@@ -23,9 +23,8 @@ spec:
     spec:
       containers:
         - args:
-            - monocle-api
-            - --port
-            - "9898"
+            - monocle
+            - api
           env:
             - name: CONFIG
               value: /etc/monocle/config.yaml
@@ -47,7 +46,7 @@ spec:
           resources: {}
           volumeMounts:
             - mountPath: /etc/monocle
-              name: monocle-config-volume 
+              name: monocle-config-volume
       restartPolicy: Always
       volumes:
         - name: monocle-config-volume

--- a/deployment/crawler-deployment.yaml
+++ b/deployment/crawler-deployment.yaml
@@ -23,7 +23,8 @@ spec:
     spec:
       containers:
         - args:
-            - macroscope
+            - monocle
+            - crawler
           env:
             - name: CONFIG
               value: /etc/monocle/config.yaml

--- a/docker-compose.dhall
+++ b/docker-compose.dhall
@@ -118,11 +118,10 @@ let createApiService =
         let service =
               { healthcheck = Some
                   ( mkHealthCheck
-                      "curl --silent --fail localhost:9898/health || exit 1"
+                      "curl --silent --fail localhost:\$MONOCLE_API_PORT/health || exit 1"
                   )
               , depends_on = Some [ "elastic" ]
-              , command = Some
-                  (Compose.StringOrList.String "monocle-api --port 9898")
+              , command = Some (Compose.StringOrList.String "monocle api")
               , volumes = Some [ "./etc:/etc/monocle:z" ]
               , env_file = envFile
               , environment = Some
@@ -155,7 +154,7 @@ let createCrawlerService =
       \(dev : Bool) ->
         let service =
               { depends_on = Some [ "api" ]
-              , command = Some (Compose.StringOrList.String "macroscope")
+              , command = Some (Compose.StringOrList.String "monocle crawler")
               , healthcheck = Some
                   ( mkHealthCheck
                       "curl --silent --fail localhost:9001/health || exit 1"

--- a/docker-compose.yml.dev
+++ b/docker-compose.yml.dev
@@ -5,7 +5,7 @@ services:
         MONOCLE_COMMIT: "${MONOCLE_COMMIT:-HEAD}"
       context: '.'
       dockerfile: Dockerfile-api
-    command: monocle-api --port 9898
+    command: monocle api
     depends_on:
       - elastic
     env_file: ".secrets"
@@ -14,7 +14,7 @@ services:
       ELASTIC_CONN: elastic:9200
     healthcheck:
       retries: 6
-      test: "curl --silent --fail localhost:9898/health || exit 1"
+      test: "curl --silent --fail localhost:$MONOCLE_API_PORT/health || exit 1"
       timeout: "60s"
     ports:
       - "${MONOCLE_API_ADDR:-0.0.0.0}:${MONOCLE_API_PORT:-9898}:9898"
@@ -26,7 +26,7 @@ services:
         MONOCLE_COMMIT: "${MONOCLE_COMMIT:-HEAD}"
       context: '.'
       dockerfile: Dockerfile-api
-    command: macroscope
+    command: monocle crawler
     depends_on:
       - api
     env_file: ".secrets"

--- a/docker-compose.yml.img
+++ b/docker-compose.yml.img
@@ -1,6 +1,6 @@
 services:
   api:
-    command: monocle-api --port 9898
+    command: monocle api
     depends_on:
       - elastic
     env_file: ".secrets"
@@ -11,14 +11,14 @@ services:
       - 9898
     healthcheck:
       retries: 6
-      test: "curl --silent --fail localhost:9898/health || exit 1"
+      test: "curl --silent --fail localhost:$MONOCLE_API_PORT/health || exit 1"
       timeout: "60s"
     image: "quay.io/change-metrics/monocle_api:${MONOCLE_VERSION:-latest}"
     restart: unless-stopped
     volumes:
       - "./etc:/etc/monocle:z"
   crawler:
-    command: macroscope
+    command: monocle crawler
     depends_on:
       - api
     env_file: ".secrets"

--- a/haskell/app/Api.hs
+++ b/haskell/app/Api.hs
@@ -1,7 +1,0 @@
-module Main (main) where
-
-import qualified CLI
-import Prelude (IO)
-
-main :: IO ()
-main = CLI.mainApi

--- a/haskell/app/Macroscope.hs
+++ b/haskell/app/Macroscope.hs
@@ -1,7 +1,0 @@
-module Main (main) where
-
-import qualified CLI
-import Prelude (IO)
-
-main :: IO ()
-main = CLI.mainMacroscope

--- a/haskell/app/Monocle.hs
+++ b/haskell/app/Monocle.hs
@@ -4,4 +4,4 @@ import qualified CLI
 import Prelude (IO)
 
 main :: IO ()
-main = CLI.mainLentille
+main = CLI.main

--- a/haskell/monocle.cabal
+++ b/haskell/monocle.cabal
@@ -94,11 +94,6 @@ common codegen
                      , text
                      , vector                     >= 0.12
 
-common cli-options
-  hs-source-dirs:      app
-  build-depends:       base, monocle
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
-
 library
   import:              common-options, codegen
   build-depends:       base                       < 5
@@ -140,6 +135,7 @@ library
                      , network                    >= 3
                      , network-uri                >= 2.5
                      , optparse-generic           >= 1.4
+                     , optparse-applicative
                      , parser-combinators         >= 1.2
                      , prometheus-client          >= 1.0
                      , prometheus-metrics-ghc     >= 1.0
@@ -242,17 +238,12 @@ library
 
   autogen-modules:     Paths_monocle
 
-executable monocle-api
-  import:              common-options, cli-options
-  main-is:             Api.hs
-
-executable macroscope
-  import:              common-options, cli-options
-  main-is:             Macroscope.hs
-
-executable lentille
-  import:              common-options, cli-options
-  main-is:             LentilleStandalone.hs
+executable monocle
+  import:              common-options
+  hs-source-dirs:      app
+  build-depends:       base, monocle
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
+  main-is:             Monocle.hs
 
 benchmark json-decode
   import:              common-options

--- a/haskell/monocle.cabal
+++ b/haskell/monocle.cabal
@@ -134,7 +134,6 @@ library
                      , mtl
                      , network                    >= 3
                      , network-uri                >= 2.5
-                     , optparse-generic           >= 1.4
                      , optparse-applicative
                      , parser-combinators         >= 1.2
                      , prometheus-client          >= 1.0


### PR DESCRIPTION
This change simplifies the command API by providing an "hyper" tool
with sub commands:

- monocle-api -> monocle api
- macroscope -> monocle crawler
- lentille -> monocle lentille

Then the janitor can be implemented as another sub command.