### PR TITLE
[update-idents] quick fix in legacy code

### DIFF
--- a/monocle/db/db.py
+++ b/monocle/db/db.py
@@ -695,13 +695,16 @@ class ELmonocleDB:
             return hash(obj_json)
 
         def update_ident(dict_ident: Dict) -> Dict:
-            dict_ident["muid"] = create_muid(dict_ident["uid"], self.idents_config)
+            if dict_ident:
+                dict_ident["muid"] = create_muid(dict_ident["uid"], self.idents_config)
             return dict_ident
 
         def _update_idents(obj: Dict) -> Tuple[Optional[Union[Change, Event]], bool]:
 
             prev_hash = get_obj_hash(obj)
 
+            if not obj.get("type"):
+                return None, False
             if obj["type"] == "Change":
                 obj["author"] = update_ident(obj["author"])
                 if "committer" in obj:

--- a/monocle/main.py
+++ b/monocle/main.py
@@ -310,9 +310,9 @@ def main() -> None:
             log.error("Please provide the --config option")
             sys.exit(1)
         if args.update_idents:
-            idents_config = config.get_idents_config(
-                yaml.safe_load(open(args.config)), args.workspace
-            )
+            realpath = os.path.expanduser(args.config)
+            configdata = config.load(open(realpath).read())
+            idents_config = config.get_idents_config(configdata, args.workspace)
         else:
             idents_config = []
         db = ELmonocleDB(


### PR DESCRIPTION
- Ensure the config is loaded with auto translation to legacy schema.
- Do not fail if object does not have the 'type' field.