### PR TITLE
[crawler] github issues - ask __typename for all Union fields

### DIFF
--- a/haskell/src/Lentille/GitHub/Issues.hs
+++ b/haskell/src/Lentille/GitHub/Issues.hs
@@ -45,6 +45,7 @@ defineByDocumentFile
         issueCount
         pageInfo {hasNextPage endCursor}
         nodes {
+          __typename
           ... on Issue {
             id
             title
@@ -61,11 +62,13 @@ defineByDocumentFile
                 __typename
                 ... on CrossReferencedEvent {
                    source {
+                      __typename
                       ... on PullRequest {url}
                    }
                 }
                 ... on ConnectedEvent {
                    subject {
+                     __typename
                      ... on PullRequest {url}
                    }
                 }


### PR DESCRIPTION
Since morpheus 0.18 it seems the that __typename is mandatory
to ensure the decoding of the response to avoid runtime errors
such as:

```
[2021-12-01 11:16:49.341] Macroscope: [sf-team-workspace] Crawler: change-metrics-crawler - Error occured when consuming the document stream: HttpError ("FetchErrorParseFailure \"Error in $.data.search.nodes[1].timelineItems.nodes[0].source: key \\\"__typename\\\" not found on object\""
```