### PR TITLE
Add support for username configuration to use `self` in queries

### DIFF
--- a/haskell/src/Monocle/Search/Query.hs
+++ b/haskell/src/Monocle/Search/Query.hs
@@ -339,12 +339,9 @@ mkProjectQuery Config.Project {..} = BH.QueryBoolQuery $ BH.mkBoolQuery must [] 
 getAuthorField :: Field -> Text -> Parser (Field, Text)
 getAuthorField fieldName = \case
   "self" -> do
-    index <- asks envIndex
     username <- asks envUsername
     when (username == mempty) (toParseError $ Left "You need to be logged in to use the self value")
-    pure $ case Config.lookupIdent index username of
-      Just muid -> (fieldName <> ".muid", muid)
-      Nothing -> (fieldName <> ".id", username)
+    pure (fieldName <> ".muid", username)
   value -> pure (fieldName <> ".muid", value)
 
 mkEqQuery :: Field -> Text -> Parser BH.Query

--- a/web/src/components/Search.res
+++ b/web/src/components/Search.res
@@ -416,7 +416,7 @@ module Top = {
     let onSave = newValue => {
       (WebApi.Search.check({
         index: state.index,
-        username: "",
+        username: state.username->Belt.Option.getWithDefault(""),
         query: value,
       }) |> Js.Promise.then_(handleCheck(newValue)))->ignore
     }

--- a/web/src/components/Store.res
+++ b/web/src/components/Store.res
@@ -7,10 +7,11 @@ module RemoteData = {
 }
 
 module UrlData = {
-  let getParam = name => {
+  let getParamOption = name => {
     let params = Prelude.URLSearchParams.current()
-    params->Prelude.URLSearchParams.get(name)->Js.Nullable.toOption->Belt.Option.getWithDefault("")
+    params->Prelude.URLSearchParams.get(name)->Js.Nullable.toOption
   }
+  let getParam = name => name->getParamOption->Belt.Option.getWithDefault("")
   let getOrder = () =>
     getParam("o")
     ->Prelude.orderFromQS
@@ -20,6 +21,20 @@ module UrlData = {
     switch getParam("q") {
     | "" => "from:now-3weeks"
     | q => q
+    }
+  let getUsername = () =>
+    switch getParamOption("username") {
+    | None =>
+      // Load from localstore
+      Dom.Storage.localStorage |> Dom.Storage.getItem("monocle_username")
+    | Some("") =>
+      // Clear local storage
+      Dom.Storage.localStorage |> Dom.Storage.removeItem("monocle_username")
+      None
+    | Some(username) =>
+      // Store in localstorage the value
+      Dom.Storage.localStorage |> Dom.Storage.setItem("monocle_username", username)
+      Some(username)
     }
   let getFilter = () => getParam("f")
   let getLimit = () => {
@@ -77,6 +92,7 @@ module Store = {
     filter: UrlData.getFilter(),
     limit: UrlData.getLimit(),
     order: UrlData.getOrder(),
+    username: UrlData.getUsername(),
     suggestions: None,
     fields: None,
     user_groups: None,

--- a/web/src/components/Store.res
+++ b/web/src/components/Store.res
@@ -44,6 +44,7 @@ module Store = {
     query: string,
     filter: string,
     limit: int,
+    username: option<string>,
     order: option<SearchTypes.order>,
     suggestions: suggestionsR,
     fields: RemoteData.t<list<SearchTypes.field>>,
@@ -198,7 +199,7 @@ let changeIndex = ((_, dispatch), name) => name->Store.ChangeIndex->dispatch
 
 let mkSearchRequest = (state: Store.t, query_type: SearchTypes.query_request_query_type) => {
   SearchTypes.index: state.index,
-  username: "",
+  username: state.username->Belt.Option.getWithDefault(""),
   query: state.query,
   query_type: query_type,
   order: state.order,


### PR DESCRIPTION
This PR let a user provide a username through the url:

- `&username=alice` : use this name and save it in the local storage
- `&username=` : remove the name from the local storage
- ``: use the name from the local storage, if any

This could use a better interface through some sort of a login modal, and to provide an indicator about the login state.