### PR TITLE
[macroscope] ensures stream group key include the Token

### DIFF
--- a/haskell/src/Macroscope/Main.hs
+++ b/haskell/src/Macroscope/Main.hs
@@ -229,7 +229,8 @@ getClientGraphQL crawler url token = do
   clients <- gets clientsGraph
   (client, newClients) <- mapMutate clients (url, token) $ lift $ newGraphClient crawler url token
   modify $ \s -> s {clientsGraph = newClients}
-  pure (url, client)
+  let groupKey = url <> "-" <> unSecret token
+  pure (groupKey, client)
 
 -- | Groups the streams by client
 --


### PR DESCRIPTION
This change updates the getClientGraphQL to include the token
value inside the stream group name.

Indeed mulitple tokens could be used with a single url and to
prepare for handling the query quota (handled by Token) we need to
separate group by url/token as streams inside a group are
processed sequentialy.