### PR TITLE
[compose] healthcheck for api - do not honor MONOCLE_API_PORT

### DIFF
--- a/docker-compose.dhall
+++ b/docker-compose.dhall
@@ -118,7 +118,7 @@ let createApiService =
         let service =
               { healthcheck = Some
                   ( mkHealthCheck
-                      "curl --silent --fail localhost:\$MONOCLE_API_PORT/health || exit 1"
+                      "curl --silent --fail localhost:9898/health || exit 1"
                   )
               , depends_on = Some [ "elastic" ]
               , command = Some (Compose.StringOrList.String "monocle api")

--- a/docker-compose.yml.dev
+++ b/docker-compose.yml.dev
@@ -14,7 +14,7 @@ services:
       ELASTIC_CONN: elastic:9200
     healthcheck:
       retries: 6
-      test: "curl --silent --fail localhost:$MONOCLE_API_PORT/health || exit 1"
+      test: "curl --silent --fail localhost:9898/health || exit 1"
       timeout: "60s"
     ports:
       - "${MONOCLE_API_ADDR:-0.0.0.0}:${MONOCLE_API_PORT:-9898}:9898"

--- a/docker-compose.yml.img
+++ b/docker-compose.yml.img
@@ -11,7 +11,7 @@ services:
       - 9898
     healthcheck:
       retries: 6
-      test: "curl --silent --fail localhost:$MONOCLE_API_PORT/health || exit 1"
+      test: "curl --silent --fail localhost:9898/health || exit 1"
       timeout: "60s"
     image: "quay.io/change-metrics/monocle_api:${MONOCLE_VERSION:-latest}"
     restart: unless-stopped


### PR DESCRIPTION
Port binding expect a fixed 9898/TCP internal port so the healthcheck
needs to follow the same rule.