### PR TITLE
Consolidate backend logging

### DIFF
--- a/haskell/monocle.cabal
+++ b/haskell/monocle.cabal
@@ -170,6 +170,7 @@ library
   exposed-modules:     Monocle.Prelude
                      , Monocle.Env
                      , Monocle.Class
+                     , Monocle.Logging
                      , Monocle.Version
                      , CLI
 

--- a/haskell/src/Lentille.hs
+++ b/haskell/src/Lentille.hs
@@ -39,7 +39,6 @@ module Lentille
 where
 
 import qualified Data.Text as T
-import Data.Time.Format (defaultTimeLocale, formatTime)
 import qualified Google.Protobuf.Timestamp as T
 import Monocle.Api.Config (MonadConfig (..))
 import qualified Monocle.Api.Config
@@ -61,6 +60,7 @@ newtype LentilleM a = LentilleM {unLentille :: ReaderT CrawlerEnv IO a}
 
 data CrawlerEnv = CrawlerEnv
   { crawlerClient :: MonocleClient,
+    crawlerLogger :: Logger,
     crawlerStop :: IORef Bool
   }
 
@@ -76,12 +76,12 @@ unlessStopped action = do
   stopped <- mReadIORef stopRef
   unless stopped action
 
-runLentilleM :: MonadIO m => MonocleClient -> LentilleM a -> m a
-runLentilleM client lm = do
+runLentilleM :: MonadIO m => Logger -> MonocleClient -> LentilleM a -> m a
+runLentilleM logger client lm = do
   r <- liftIO $ newIORef False
   liftIO . flip runReaderT (env r) . unLentille $ lm
   where
-    env = CrawlerEnv client
+    env = CrawlerEnv client logger
 
 stopLentille :: MonadThrow m => LentilleError -> LentilleStream m a
 stopLentille = lift . throwM
@@ -141,12 +141,12 @@ type LentilleMonad m =
 -- Log system
 -------------------------------------------------------------------------------
 
-logEvent :: (MonadTime m, MonadIO m) => Log -> m ()
+logEvent :: Log -> LentilleM ()
 logEvent x = do
-  now <- mGetCurrentTime
-  say $ "[" <> showTime now <> "] " <> from x
+  logger <- asks crawlerLogger
+  liftIO $ doLog logger message
   where
-    showTime now = toText . take 23 $ formatTime defaultTimeLocale "%F %T.%q" now
+    message = encodeUtf8 @Text @ByteString . from $ x
 
 logRaw :: MonadLog m => Text -> m ()
 logRaw text = mLog $ Log Unspecified (LogRaw text)

--- a/haskell/src/Lentille.hs
+++ b/haskell/src/Lentille.hs
@@ -46,6 +46,7 @@ import qualified Monocle.Api.Config
 import Monocle.Change (Change (changeUpdatedAt), ChangeEvent, Change_ChangeState (Change_ChangeStateClosed, Change_ChangeStateMerged), Ident (..))
 import Monocle.Class
 import Monocle.Client (MonocleClient, baseUrl, mkManager)
+import Monocle.Logging
 import Monocle.Prelude
 import qualified Network.HTTP.Client as HTTP
 import Proto3.Suite (Enumerated (Enumerated))

--- a/haskell/src/Macroscope/Main.hs
+++ b/haskell/src/Macroscope/Main.hs
@@ -79,12 +79,13 @@ withMonitoringServer port action = do
 -- | 'runMacroscope is the entrypoint of the macroscope process
 -- withClient "http://localhost:8080" Nothing $ \client -> runMacroscope 9001 "/home/user/git/github.com/change-metrics/monocle/etc/config.yaml" client
 runMacroscope :: Int -> FilePath -> MonocleClient -> IO ()
-runMacroscope port confPath client = withMonitoringServer port $ do
-  runLentilleM client $ do
+runMacroscope port confPath client = withMonitoringAndLogger $ \logger -> do
+  runLentilleM logger client $ do
     mLog $ Log Macroscope LogMacroStart
     config <- Config.mReloadConfig confPath
     loop config (from ())
   where
+    withMonitoringAndLogger = withMonitoringServer port . withLogger
     loop config clients = do
       -- Load the config
       conf <- Config.csConfig <$> config

--- a/haskell/src/Monocle/Api.hs
+++ b/haskell/src/Monocle/Api.hs
@@ -5,6 +5,7 @@ import Lentille (retry)
 import qualified Monocle.Api.Config as Config
 import qualified Monocle.Backend.Index as I
 import Monocle.Env
+import Monocle.Logging
 import Monocle.Prelude
 import Monocle.Search.Query (loadAliases)
 import Monocle.Servant.HTTP (MonocleAPI, server)
@@ -66,7 +67,7 @@ run' port url configFile glLogger = do
   liftIO $
     withStdoutLogger $ \aplogger -> do
       let settings = Warp.setPort port $ Warp.setLogger aplogger Warp.defaultSettings
-      logEvent glLogger $ SystemReady (length workspaces) port url
+      doLog glLogger $ via @Text $ SystemReady (length workspaces) port url
       Warp.runSettings
         settings
         . cors (const $ Just policy)

--- a/haskell/src/Monocle/Api/Server.hs
+++ b/haskell/src/Monocle/Api/Server.hs
@@ -8,7 +8,6 @@ import qualified Data.Vector as V
 import Google.Protobuf.Timestamp as Timestamp
 import qualified Google.Protobuf.Timestamp as T
 import qualified Monocle.Api.Config as Config
-import Monocle.Logging
 import Monocle.Backend.Documents
   ( EChange (..),
     EChangeEvent (..),
@@ -18,6 +17,7 @@ import qualified Monocle.Backend.Queries as Q
 import qualified Monocle.Config as ConfigPB
 import qualified Monocle.Crawler as CrawlerPB
 import Monocle.Env
+import Monocle.Logging
 import qualified Monocle.Login as LoginPB
 import qualified Monocle.Metric as MetricPB
 import Monocle.Prelude

--- a/haskell/src/Monocle/Api/Server.hs
+++ b/haskell/src/Monocle/Api/Server.hs
@@ -8,6 +8,7 @@ import qualified Data.Vector as V
 import Google.Protobuf.Timestamp as Timestamp
 import qualified Google.Protobuf.Timestamp as T
 import qualified Monocle.Api.Config as Config
+import Monocle.Logging
 import Monocle.Backend.Documents
   ( EChange (..),
     EChangeEvent (..),
@@ -51,8 +52,7 @@ updateIndex index wsRef = runEmptyQueryM index $ modifyMVar_ wsRef doUpdateIfNee
 
     refreshIndex :: QueryM ()
     refreshIndex = do
-      logger <- glLogger <$> asks tEnv
-      liftIO $ logEvent logger $ RefreshIndex index
+      logEvent $ RefreshIndex index
       I.ensureIndexSetup
       traverse_ I.initCrawlerMetadata $ Config.crawlers index
 
@@ -275,11 +275,11 @@ crawlerAddDoc request = do
     Left err -> pure $ toErrorResponse err
   where
     addTDs crawlerName taskDatas = do
-      monocleLogEvent $ AddingTaskData crawlerName (length taskDatas)
+      logEvent $ AddingTaskData crawlerName (length taskDatas)
       I.taskDataAdd (toText crawlerName) $ toList taskDatas
       pure $ CrawlerPB.AddDocResponse Nothing
     addChanges crawlerName changes events = do
-      monocleLogEvent $ AddingChange crawlerName (length changes) (length events)
+      logEvent $ AddingChange crawlerName (length changes) (length events)
       let changes' = map from $ toList changes
           events' = map I.toEChangeEvent $ toList events
       I.indexChanges changes'
@@ -287,7 +287,7 @@ crawlerAddDoc request = do
       I.updateChangesAndEventsFromOrphanTaskData changes' events'
       pure $ CrawlerPB.AddDocResponse Nothing
     addProjects crawler organizationName projects = do
-      monocleLogEvent $ AddingProject (getWorkerName crawler) organizationName (length projects)
+      logEvent $ AddingProject (getWorkerName crawler) organizationName (length projects)
       let names = projectNames projects
           -- TODO(fbo) Enable crawl github issues by default for an organization.
           -- We might need to re-think some data fetching like priority/severity.
@@ -333,7 +333,7 @@ crawlerCommit request = do
   case requestE of
     Right (index, ts, entity) -> runEmptyQueryM index $ do
       let date = Timestamp.toUTCTime ts
-      monocleLogEvent $ UpdatingEntity crawlerName entity date
+      logEvent $ UpdatingEntity crawlerName entity date
       -- TODO: check for CommitDateInferiorThanPrevious
       _ <- I.setLastUpdated (toStrict crawlerName) date entity
 
@@ -498,7 +498,7 @@ searchQuery request = do
   case requestE of
     Right (tenant, query) -> runQueryM tenant (Q.ensureMinBound query) $ do
       let queryType = fromPBEnum queryRequestQueryType
-      monocleLogEvent $ Searching queryType queryRequestQuery query
+      logEvent $ Searching queryType queryRequestQuery query
 
       case queryType of
         SearchPB.QueryRequest_QueryTypeQUERY_CHANGE ->

--- a/haskell/src/Monocle/Api/Test.hs
+++ b/haskell/src/Monocle/Api/Test.hs
@@ -23,7 +23,7 @@ mkAppEnv workspace = do
       aEnv = Env {..}
   pure $ AppEnv {..}
 
-withTestApi :: IO AppEnv -> (MonocleClient -> Assertion) -> IO ()
+withTestApi :: IO AppEnv -> (Logger -> MonocleClient -> Assertion) -> IO ()
 withTestApi appEnv' testCb = bracket appEnv' cleanIndex runTest
   where
     -- Using a mockedManager, run the Api behind a MonocleClient for the tests
@@ -36,7 +36,7 @@ withTestApi appEnv' testCb = bracket appEnv' cleanIndex runTest
         indexes
       withMockedManager
         (dropVersionPath $ app appEnv)
-        (\manager -> withClient "http://localhost" (Just manager) testCb)
+        (\manager -> withLogger $ \logger -> withClient "http://localhost" (Just manager) (testCb logger))
     dropVersionPath app' req = do
       app'
         ( req

--- a/haskell/src/Monocle/Backend/Index.hs
+++ b/haskell/src/Monocle/Backend/Index.hs
@@ -18,6 +18,7 @@ import Monocle.Change
 import Monocle.Crawler (EntityEntity (EntityEntityProjectName))
 import qualified Monocle.Crawler as CrawlerPB
 import Monocle.Env
+import Monocle.Logging (Entity (..), getEntityName)
 import Monocle.Prelude
 import Monocle.Search (Order (..), Order_Direction (..), TaskData (..))
 import qualified Network.HTTP.Client as HTTP

--- a/haskell/src/Monocle/Backend/Test.hs
+++ b/haskell/src/Monocle/Backend/Test.hs
@@ -18,6 +18,7 @@ import qualified Monocle.Backend.Janitor as J
 import qualified Monocle.Backend.Queries as Q
 import qualified Monocle.Crawler as CrawlerPB
 import Monocle.Env
+import Monocle.Logging
 import Monocle.Prelude
 import Monocle.Search (TaskData (..))
 import qualified Monocle.Search as SearchPB

--- a/haskell/src/Monocle/Class.hs
+++ b/haskell/src/Monocle/Class.hs
@@ -4,11 +4,11 @@ module Monocle.Class where
 import qualified Control.Concurrent (modifyMVar, newMVar, threadDelay)
 import Control.Retry (RetryStatus (..))
 import qualified Control.Retry as Retry
-import qualified Data.Text as T
 import qualified Data.Time.Clock (getCurrentTime)
 import Monocle.Client (MonocleClient, mkManager)
 import Monocle.Client.Api (crawlerAddDoc, crawlerCommit, crawlerCommitInfo)
 import Monocle.Crawler (AddDocRequest, AddDocResponse, CommitInfoRequest, CommitInfoResponse, CommitRequest, CommitResponse)
+import Monocle.Logging
 import Monocle.Prelude
 import Network.HTTP.Client (HttpException (..))
 import qualified Network.HTTP.Client as HTTP
@@ -55,61 +55,6 @@ data Log = Log {author :: LogAuthor, event :: LogEvent}
 
 instance From Log Text where
   from Log {..} = from author <> ": " <> from event
-
-data LogCrawlerContext = LogCrawlerContext {index :: Text, crawler :: Text}
-
-data LogEvent
-  = LogMacroStart
-  | LogStartingMonitoring Int
-  | LogMacroPause Word32
-  | LogMacroStartCrawlers [Text]
-  | LogMacroContinue LogCrawlerContext
-  | LogMacroSkipCrawler LogCrawlerContext Text
-  | LogMacroStartCrawler LogCrawlerContext
-  | LogMacroPostData LogCrawlerContext Text Int
-  | LogMacroRequestOldestEntity LogCrawlerContext Text
-  | LogMacroGotOldestEntity LogCrawlerContext (Text, Text) UTCTime
-  | LogMacroNoOldestEnity LogCrawlerContext
-  | LogMacroEnded LogCrawlerContext
-  | LogMacroCommitFailed LogCrawlerContext
-  | LogMacroPostDataFailed LogCrawlerContext [Text]
-  | LogMacroStreamError LogCrawlerContext Text
-  | LogMacroGroupStart Text
-  | LogMacroGroupEnd Text
-  | LogMacroReloadingStart
-  | LogNetworkFailure Text
-  | LogGetBugs UTCTime Int Int
-  | LogGraphQL LogCrawlerContext Text
-  | LogRaw Text
-
-instance From LogEvent Text where
-  from = \case
-    LogMacroStart -> "Starting to fetch streams"
-    LogStartingMonitoring port -> "Starting monitoring service on port " <> show port
-    LogMacroPause usec -> "Waiting " <> show usec <> " sec. brb"
-    LogMacroStartCrawlers xs -> "Starting " <> show (length xs) <> " threads for " <> show xs
-    LogMacroContinue lc -> prefix lc <> " - Continuing on next entity"
-    LogMacroSkipCrawler lc err -> prefix lc <> " - Skipping due to an unexpected exception catched: " <> err
-    LogMacroStartCrawler lc -> prefix lc <> " - Start crawling entities"
-    LogMacroPostData lc eName count -> prefix lc <> " - Posting " <> show count <> " documents to: " <> eName
-    LogMacroRequestOldestEntity lc entity -> prefix lc <> " - Looking for oldest refreshed " <> entity <> " entity"
-    LogMacroGotOldestEntity lc (etype, name) date ->
-      prefix lc <> " - Got entity of type: " <> etype <> " named: " <> name <> " last updated at " <> show date
-    LogMacroNoOldestEnity lc -> prefix lc <> " - Unable to find entity to update"
-    LogMacroEnded lc -> prefix lc <> " - Crawling entities completed"
-    LogMacroCommitFailed lc -> prefix lc <> " - Commit date failed"
-    LogMacroPostDataFailed lc errors -> prefix lc <> " - Post documents failed: " <> T.intercalate " | " errors
-    LogMacroStreamError lc error' -> prefix lc <> " - Error occured when consuming the document stream: " <> error'
-    LogNetworkFailure msg -> "Network error: " <> msg
-    LogGetBugs ts offset limit ->
-      "Getting bugs from " <> show ts <> " offset " <> show offset <> " limit " <> show limit
-    LogMacroGroupStart name -> "Group start: " <> name
-    LogMacroGroupEnd name -> "Group end: " <> name
-    LogMacroReloadingStart -> "Macroscope reloading beging"
-    LogGraphQL lc text -> prefix lc <> " - " <> text
-    LogRaw t -> t
-    where
-      prefix LogCrawlerContext {..} = "[" <> index <> "] " <> "Crawler: " <> crawler
 
 class (Monad m, MonadTime m) => MonadLog m where
   mLog :: Log -> m ()

--- a/haskell/src/Monocle/Class.hs
+++ b/haskell/src/Monocle/Class.hs
@@ -43,7 +43,6 @@ instance MonadSync IO where
 
 -------------------------------------------------------------------------------
 -- A log system
-
 data LogAuthor = Macroscope | Unspecified
 
 instance From LogAuthor Text where

--- a/haskell/src/Monocle/Env.hs
+++ b/haskell/src/Monocle/Env.hs
@@ -12,7 +12,6 @@ import qualified Monocle.Search.Query as Q
 import Monocle.Search.Syntax (Expr)
 import qualified Network.HTTP.Client as HTTP
 import qualified Servant (Handler)
-import qualified System.Log.FastLogger as FastLogger
 
 -------------------------------------------------------------------------------
 -- The main AppM context, embeded in the Servant handler
@@ -268,22 +267,6 @@ getEntityName = \case
 -------------------------------------------------------------------------------
 -- logging function
 -------------------------------------------------------------------------------
-type Logger = FastLogger.TimedFastLogger
-
--- | withLogger create the logger
---
--- try with repl:
--- λ> runQueryM' Prelude.undefined (Config.defaultTenant "tenant") $ monocleLogEvent (AddingChange "test" 42 42)
-withLogger :: (Logger -> IO a) -> IO a
-withLogger cb = do
-  tc <- liftIO $ FastLogger.newTimeCache "%F %T "
-  FastLogger.withTimedFastLogger tc logger cb
-  where
-    logger = FastLogger.LogStderr 1024
-
-doLog :: Logger -> ByteString -> IO ()
-doLog logger message = logger (\time -> FastLogger.toLogStr $ time <> message <> "\n")
-
 data SystemEvent
   = SystemReady Int Int Text
   | ReloadConfig FilePath

--- a/haskell/src/Monocle/Env.hs
+++ b/haskell/src/Monocle/Env.hs
@@ -6,8 +6,8 @@ import qualified Database.Bloodhound.Raw as BHR
 import GHC.Stack (srcLocFile, srcLocStartLine)
 import qualified Json.Extras as Json
 import qualified Monocle.Api.Config as Config
+import Monocle.Logging
 import Monocle.Prelude
-import Monocle.Search (QueryRequest_QueryType (..))
 import qualified Monocle.Search.Query as Q
 import Monocle.Search.Syntax (Expr)
 import qualified Network.HTTP.Client as HTTP
@@ -246,67 +246,11 @@ withFilter extraQueries = local addFilter
       let newQueryGet modifier qf = extraQueries <> Q.queryGet query modifier qf
        in QueryEnv tenant tEnv (query {Q.queryGet = newQueryGet}) context
 
-data Entity = Project Text | Organization Text | TaskDataEntity Text
-  deriving (Eq, Show)
-
-instance From Entity Text where
-  from = \case
-    Project _ -> "project"
-    Organization _ -> "organization"
-    TaskDataEntity _ -> "taskdata"
-
-instance From Entity LText where
-  from = via @Text
-
-getEntityName :: Entity -> Text
-getEntityName = \case
-  Project n -> n
-  Organization n -> n
-  TaskDataEntity n -> n
-
 -------------------------------------------------------------------------------
 -- logging function
 -------------------------------------------------------------------------------
-data SystemEvent
-  = SystemReady Int Int Text
-  | ReloadConfig FilePath
-  | RefreshIndex Config.Index
-
-sysEventToText :: SystemEvent -> ByteString
-sysEventToText = \case
-  SystemReady tenantCount port url ->
-    "Serving " <> show tenantCount <> " tenant(s) on 0.0.0.0:" <> show port <> " with elastic: " <> encodeUtf8 url
-  RefreshIndex index ->
-    encodeUtf8 $ "Ensure workspace: " <> Config.getWorkspaceName index <> " exists and refresh crawlers metadata"
-  ReloadConfig fp ->
-    "Reloading " <> encodeUtf8 fp
-
-logEvent :: Logger -> SystemEvent -> IO ()
-logEvent logger ev = doLog logger (sysEventToText ev)
-
-data MonocleEvent
-  = AddingChange LText Int Int
-  | AddingProject Text Text Int
-  | AddingTaskData LText Int
-  | UpdatingEntity LText Entity UTCTime
-  | Searching QueryRequest_QueryType LText Q.Query
-
-eventToText :: MonocleEvent -> Text
-eventToText ev = case ev of
-  AddingChange crawler changes events ->
-    toStrict crawler <> " adding " <> show changes <> " changes with " <> show events <> " events"
-  AddingProject crawler organizationName projects ->
-    crawler <> " adding " <> show projects <> " changes for organization: " <> organizationName
-  AddingTaskData crawler tds ->
-    toStrict crawler <> " adding " <> show tds
-  UpdatingEntity crawler entity ts ->
-    toStrict crawler <> " updating " <> show entity <> " to " <> show ts
-  Searching queryType queryText query ->
-    let jsonQuery = decodeUtf8 . encode $ Q.queryGet query id Nothing
-     in "searching " <> show queryType <> " with `" <> toStrict queryText <> "`: " <> jsonQuery
-
-monocleLogEvent :: MonocleEvent -> QueryM ()
-monocleLogEvent ev = do
+logEvent :: LogEvent -> QueryM ()
+logEvent ev = do
   Config.Index {..} <- getIndexConfig
   logger <- asks (glLogger . tEnv)
-  liftIO $ doLog logger (encodeUtf8 $ name <> ": " <> eventToText ev)
+  liftIO $ doLog logger (encodeUtf8 $ name <> ": " <> from ev)

--- a/haskell/src/Monocle/Logging.hs
+++ b/haskell/src/Monocle/Logging.hs
@@ -2,9 +2,30 @@
 module Monocle.Logging where
 
 import qualified Data.Text as T
+import qualified Monocle.Api.Config as Config
 import Monocle.Prelude
+import Monocle.Search (QueryRequest_QueryType (..))
+import qualified Monocle.Search.Query as Q
 
 data LogCrawlerContext = LogCrawlerContext {index :: Text, crawler :: Text}
+
+data Entity = Project Text | Organization Text | TaskDataEntity Text
+  deriving (Eq, Show)
+
+instance From Entity Text where
+  from = \case
+    Project _ -> "project"
+    Organization _ -> "organization"
+    TaskDataEntity _ -> "taskdata"
+
+instance From Entity LText where
+  from = via @Text
+
+getEntityName :: Entity -> Text
+getEntityName = \case
+  Project n -> n
+  Organization n -> n
+  TaskDataEntity n -> n
 
 data LogEvent
   = LogMacroStart
@@ -29,6 +50,14 @@ data LogEvent
   | LogGetBugs UTCTime Int Int
   | LogGraphQL LogCrawlerContext Text
   | LogRaw Text
+  | AddingChange LText Int Int
+  | AddingProject Text Text Int
+  | AddingTaskData LText Int
+  | UpdatingEntity LText Entity UTCTime
+  | Searching QueryRequest_QueryType LText Q.Query
+  | SystemReady Int Int Text
+  | ReloadConfig FilePath
+  | RefreshIndex Config.Index
 
 instance From LogEvent Text where
   from = \case
@@ -56,5 +85,22 @@ instance From LogEvent Text where
     LogMacroReloadingStart -> "Macroscope reloading beging"
     LogGraphQL lc text -> prefix lc <> " - " <> text
     LogRaw t -> t
+    AddingChange crawler changes events ->
+      toStrict crawler <> " adding " <> show changes <> " changes with " <> show events <> " events"
+    AddingProject crawler organizationName projects ->
+      crawler <> " adding " <> show projects <> " changes for organization: " <> organizationName
+    AddingTaskData crawler tds ->
+      toStrict crawler <> " adding " <> show tds
+    UpdatingEntity crawler entity ts ->
+      toStrict crawler <> " updating " <> show entity <> " to " <> show ts
+    Searching queryType queryText query ->
+      let jsonQuery = decodeUtf8 . encode $ Q.queryGet query id Nothing
+       in "searching " <> show queryType <> " with `" <> toStrict queryText <> "`: " <> jsonQuery
+    SystemReady tenantCount port url ->
+      "Serving " <> show tenantCount <> " tenant(s) on 0.0.0.0:" <> show port <> " with elastic: " <> url
+    RefreshIndex index ->
+      "Ensure workspace: " <> Config.getWorkspaceName index <> " exists and refresh crawlers metadata"
+    ReloadConfig fp ->
+      "Reloading " <> from fp
     where
       prefix LogCrawlerContext {..} = "[" <> index <> "] " <> "Crawler: " <> crawler

--- a/haskell/src/Monocle/Logging.hs
+++ b/haskell/src/Monocle/Logging.hs
@@ -1,0 +1,60 @@
+-- | Monocle log events
+module Monocle.Logging where
+
+import qualified Data.Text as T
+import Monocle.Prelude
+
+data LogCrawlerContext = LogCrawlerContext {index :: Text, crawler :: Text}
+
+data LogEvent
+  = LogMacroStart
+  | LogStartingMonitoring Int
+  | LogMacroPause Word32
+  | LogMacroStartCrawlers [Text]
+  | LogMacroContinue LogCrawlerContext
+  | LogMacroSkipCrawler LogCrawlerContext Text
+  | LogMacroStartCrawler LogCrawlerContext
+  | LogMacroPostData LogCrawlerContext Text Int
+  | LogMacroRequestOldestEntity LogCrawlerContext Text
+  | LogMacroGotOldestEntity LogCrawlerContext (Text, Text) UTCTime
+  | LogMacroNoOldestEnity LogCrawlerContext
+  | LogMacroEnded LogCrawlerContext
+  | LogMacroCommitFailed LogCrawlerContext
+  | LogMacroPostDataFailed LogCrawlerContext [Text]
+  | LogMacroStreamError LogCrawlerContext Text
+  | LogMacroGroupStart Text
+  | LogMacroGroupEnd Text
+  | LogMacroReloadingStart
+  | LogNetworkFailure Text
+  | LogGetBugs UTCTime Int Int
+  | LogGraphQL LogCrawlerContext Text
+  | LogRaw Text
+
+instance From LogEvent Text where
+  from = \case
+    LogMacroStart -> "Starting to fetch streams"
+    LogStartingMonitoring port -> "Starting monitoring service on port " <> show port
+    LogMacroPause usec -> "Waiting " <> show usec <> " sec. brb"
+    LogMacroStartCrawlers xs -> "Starting " <> show (length xs) <> " threads for " <> show xs
+    LogMacroContinue lc -> prefix lc <> " - Continuing on next entity"
+    LogMacroSkipCrawler lc err -> prefix lc <> " - Skipping due to an unexpected exception catched: " <> err
+    LogMacroStartCrawler lc -> prefix lc <> " - Start crawling entities"
+    LogMacroPostData lc eName count -> prefix lc <> " - Posting " <> show count <> " documents to: " <> eName
+    LogMacroRequestOldestEntity lc entity -> prefix lc <> " - Looking for oldest refreshed " <> entity <> " entity"
+    LogMacroGotOldestEntity lc (etype, name) date ->
+      prefix lc <> " - Got entity of type: " <> etype <> " named: " <> name <> " last updated at " <> show date
+    LogMacroNoOldestEnity lc -> prefix lc <> " - Unable to find entity to update"
+    LogMacroEnded lc -> prefix lc <> " - Crawling entities completed"
+    LogMacroCommitFailed lc -> prefix lc <> " - Commit date failed"
+    LogMacroPostDataFailed lc errors -> prefix lc <> " - Post documents failed: " <> T.intercalate " | " errors
+    LogMacroStreamError lc error' -> prefix lc <> " - Error occured when consuming the document stream: " <> error'
+    LogNetworkFailure msg -> "Network error: " <> msg
+    LogGetBugs ts offset limit ->
+      "Getting bugs from " <> show ts <> " offset " <> show offset <> " limit " <> show limit
+    LogMacroGroupStart name -> "Group start: " <> name
+    LogMacroGroupEnd name -> "Group end: " <> name
+    LogMacroReloadingStart -> "Macroscope reloading beging"
+    LogGraphQL lc text -> prefix lc <> " - " <> text
+    LogRaw t -> t
+    where
+      prefix LogCrawlerContext {..} = "[" <> index <> "] " <> "Crawler: " <> crawler

--- a/haskell/src/Monocle/Test/Spec.hs
+++ b/haskell/src/Monocle/Test/Spec.hs
@@ -105,7 +105,7 @@ monocleApiTests =
                   ]
               )
               reloadedRef
-      withTestApi appEnv $ \client ->
+      withTestApi appEnv $ \_logger client ->
         do
           -- Run two commitInfo requests (and expect same resp)
           resp1 <- crawlerCommitInfo client $ mkReq wsName1 0


### PR DESCRIPTION
This change adds fast-logger to the crawler, and merge both log event data types.

Fixes #803 