### PR TITLE
[DOC] Some improvements on nix commands/README.md/CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,16 @@
 # Contributing
 
 This document provides some instructions to get started with Monocle development. It covers topics
-such as running tests, running services w/o docker-compose or running the codegen.
+such as running tests, running services or running the codegen.
 
 ## Understanding the design choices
 
 Follow the [Architectural Decision Records](doc/adr/index.md) to understand the choices made by the project.
 
 ## Deploy from source code
+
+See [Instructions from the README.md](README.md#checkout-the-code) to checkout the code and prepare
+the .secret file.
 
 ### Running the services manually
 
@@ -99,7 +102,8 @@ cabal repl monocle
 The Monocle React WebAPP (hot reload is enabled).
 
 ```ShellSession
-./contrib/start-web.sh
+cd web
+REACT_APP_API_URL=http://localhost:8081 npm start
 firefox http://localhost:3000
 ```
 
@@ -121,11 +125,6 @@ cabal repl monocle
 
 This section describes how to start the Monocle services directly on your host using nix.
 
-Note that the commands below can be started in emacs buffer using:
-
-```ShellSession
-nix-shell --command launch-monocle-with-emacs
-```
 
 #### HTTP gateway (nginx)
 
@@ -136,22 +135,17 @@ nix-shell --command nginx-start
 #### ElasticSearch
 
 ```ShellSession
-nix-shell --command elk-start
+nix-shell --command elasticsearch-start
 ```
 
 #### API
 
 ```ShellSession
-nix-shell --command monocle-api2-start
+nix-shell --command monocle-repl
 λ> import Monocle.Api
 λ> run 19875 "http://localhost:19200" "../etc/config.yaml"
 ```
 
-In another terminal you could run ghcid with
-
-```ShellSession
-nix-shell --command monocle-ghcid
-```
 
 #### Web
 
@@ -163,11 +157,17 @@ firefox http://localhost:13000
 #### Start crawlers process
 
 ```ShellSession
-nix-shell --command monocle-api2-start
+nix-shell --command monocle-repl
 λ> import Macroscope.Worker
 λ> import Macroscope.Main
 λ> import Monocle.Client (withClient)
 λ> withClient "http://localhost:18080" Nothing $ \client -> runMacroscope 19001 "../etc/config.yaml" client
+```
+
+#### Run ghcid
+
+```ShellSession
+nix-shell --command monocle-ghcid
 ```
 
 ## Contributing a new driver
@@ -178,8 +178,7 @@ source of knowledge to hack on a new crawler.
 
 ## Running tests
 
-Tests rely on the Elasticsearch service so first you need to ensure the ElasticSearch is running on your system. To start the service use the script `contrib/start-elk.sh` or the
-related nix-shell command.
+Tests rely on the Elasticsearch service so first you need to ensure the ElasticSearch is running on your system. To start the service use the script `contrib/start-elk.sh` or the related nix-shell command.
 
 ### On the Haskell code base
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ and to detect anomalies in the way changes are produced and reviewed.
 
 Monocle supports GitHub, GitLab and Gerrit.
 
-Explore the website and blog: [changemetrics.io website](https://changemetrics.io)
+How to get started with Monocle:
 
-Try on the demo instance: [demo.changemetrics.io](https://demo.changemetrics.io)
-
-Chat with us in the project Matrix room: [#monocle:matrix.org](https://matrix.to/#/#monocle:matrix.org)
+- Explore the website and blog: [changemetrics.io](https://changemetrics.io)
+- Try on the demo instance: [demo.changemetrics.io](https://demo.changemetrics.io)
+- Chat with us in the project Matrix room: [#monocle:matrix.org](https://matrix.to/#/#monocle:matrix.org)
+- Run your own instance: [Read the installation guide](#installation)
+- Hack on it: [Read the contributing guide](CONTRIBUTING.md)
 
 ## Screenshots of Monocle from the demo instance
 
@@ -37,21 +39,17 @@ and then how to start the web UI to browse metrics.
 
 The deployment is based on Docker via a docker-compose definition.
 
-### Clone and create the needed directories
+Note that you can also [deploy from source code](CONTRIBUTING.md#deploy-from-source-code).
+
+### Checkout the code
 
 ```Shell
-$ git clone https://github.com/change-metrics/monocle.git
-$ cd monocle
-$ git submodule update --init --recursive
-$ echo CRAWLERS_API_KEY=$(uuidgen) > .secrets
-$ ln -s docker-compose.yml.img docker-compose.yml
+git clone https://github.com/change-metrics/monocle.git
+cd monocle
+git submodule update --init --recursive
+# Init a .secret file with a default API key for the crawler process
+echo CRAWLERS_API_KEY=$(uuidgen) > .secrets
 ```
-
-By default docker-compose will fetch the latest published container images.
-Indeed, we produce Docker container images for the master version of Monocle.
-If running master does not fit your needs, you could still use the last release
-by setting the MONOCLE_VERSION to 1.3.0 in the .env file. Please refer
-to [System configuration section](#system).
 
 ### Create the config.yaml file
 
@@ -83,25 +81,37 @@ the configuration.
 
 ### Start docker-compose
 
+By default docker-compose will fetch the latest published container images.
+Indeed, we produce container images for the master version of Monocle.
+If running master does not fit your needs, you could still use the last release
+by setting the MONOCLE_VERSION to 1.3.0 in the .env file. Please refer
+to [System configuration section](#system).
+
 Start Monocle:
 
 ```ShellSession
-$ docker-compose up -d
+# Set to the Docker compose file to use the published container images
+ln -s docker-compose.yml.img docker-compose.yml
+# Then start services
+docker-compose up -d
 ```
 
-Ensure services are running:
+Ensure services are running and healthy:
 
 ```ShellSession
-$ docker-compose ps
+docker-compose ps
 ```
 
-You might need to check the crawler logs to ensure the crawler started to fetch changes:
+Inspect services logs:
 
 ```ShellSession
-$ docker-compose logs -f crawler
+docker-compose logs -f
 ```
 
 You should be able to access the web UI at <http://localhost:8080>.
+
+See [Troubleshooting](#troubleshooting) section if needed. 
+
 
 ## Configuration
 
@@ -470,10 +480,6 @@ for service in prometheus grafana; do systemctl --user start monocle-$service; d
 ```
 
 4. Check metrics with grafana dashboard at http://localhost:19030/ (login with 'admin:secret')
-
-## Contributing
-
-Follow [our contributing guide](CONTRIBUTING.md).
 
 [monocle-protobuf]: ./protos/monocle
 [monocle-openapi]: ./doc/openapi.yaml

--- a/haskell/README.md
+++ b/haskell/README.md
@@ -1,21 +1,3 @@
 # monocle haskell
 
 [![AGPL-3.0-only license](https://img.shields.io/badge/license-AGPL--3.0--only-blue.svg)](LICENSE)
-
-This repository contains a Haskell library for monocle.
-
-## Contributing
-
-Contributions are very welcome!
-To get started, run:
-
-```ShellSession
-# Install the toolchain, for example on fedora>=33:
-dnf install -y ghc cabal-install zlib-devel git && cabal update
-
-# Run the tests:
-cabal test all
-
-# Start a repl:
-cabal repl monocle
-```

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -130,7 +130,7 @@ let
 
   # local devel env
   nginx-port = 18080;
-  monocle2-port = 19875;
+  monocle-port = 19875;
   web-port = 13000;
   prom-port = 19090;
   grafana-port = 19030;
@@ -218,7 +218,7 @@ in rec {
     ${headers}
 
     # config from env
-    API_TARGET=''${API_TARGET:-localhost:${toString monocle2-port}}
+    API_TARGET=''${API_TARGET:-localhost:${toString monocle-port}}
     CRAWLER_TARGET=''${CRAWLER_TARGET:-localhost:9001}
     LISTEN=''${PROMETHEUS_TARGET:-0.0.0.0:${toString prom-port}}
 
@@ -378,12 +378,12 @@ in rec {
           gzip_types text/plain text/xml application/javascript text/css;
 
           location /api/2/ {
-             proxy_pass http://localhost:${toString monocle2-port}/;
+             proxy_pass http://localhost:${toString monocle-port}/;
              proxy_http_version 1.1;
           }
 
           location /auth {
-              proxy_pass http://localhost:${toString monocle2-port}/auth;
+              proxy_pass http://localhost:${toString monocle-port}/auth;
               proxy_http_version 1.1;
           }
 
@@ -407,7 +407,7 @@ in rec {
     exec ${pkgs.nginx}/bin/nginx -c ${nginxConf} -p ${nginx-home}/ -g "daemon off;"
   '';
 
-  monocleApi2Start = pkgs.writeScriptBin "monocle-api2-start" ''
+  monocleReplStart = pkgs.writeScriptBin "monocle-repl" ''
     #!/bin/sh
     set -ex
     export $(cat .secrets)
@@ -467,7 +467,7 @@ in rec {
         (monocle-startp "nginx" "${nginxStart}" )
         (monocle-startp "prometheus" "${promStart}" )
         (monocle-startp "grafana" "${grafanaStart}" )
-        (monocle-startp "monocle-api2" "${monocleApi2Start}" )
+        (monocle-startp "monocle-api" "${monocleReplStart}" )
         (monocle-startp "monocle-web" "${monocleWebStart}" ))
 
       (monocle-start)
@@ -485,7 +485,7 @@ in rec {
     nginxStart
     promStart
     grafanaStart
-    monocleApi2Start
+    monocleReplStart
     monocleWebStart
     monocleEmacsStart
     monocleGhcid


### PR DESCRIPTION
- Renamed monocle-api2-start to monocle-repl
- Cleaning haskell/README.md as it was a duplicate of CONTRIBUTING.md
- Some slight re-org and intro improvement
- Reflecting nix changes into the CONTRIBUTING.md file
- Replace instruction regarding start-web.sh that has been removed from
  contrib/