### PR TITLE
[crawler] Enable settings TLS_CIPHERS openssl option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [master]
 ### Added
+
+- [crawler] A new env var "TLS_CIPHERS" to override the default OpenSSL cyphers list.
+
 ### Changed
 ### Removed
 ### Fixed

--- a/haskell/src/Monocle/Client.hs
+++ b/haskell/src/Monocle/Client.hs
@@ -45,7 +45,8 @@ mkManager = do
   let opensslSettings = case disableTlsM of
         Just _ -> OpenSSL.defaultOpenSSLSettings {OpenSSL.osslSettingsVerifyMode = VerifyNone}
         Nothing -> OpenSSL.defaultOpenSSLSettings
-  ctx <- OpenSSL.defaultMakeContext opensslSettings
+  tlsCiphers <- fromMaybe "DEFAULT" <$> lookupEnv "TLS_CIPHERS"
+  ctx <- OpenSSL.defaultMakeContext (opensslSettings {OpenSSL.osslSettingsCiphers = tlsCiphers})
   newManager $ OpenSSL.opensslManagerSettings (pure ctx)
 
 -- | Create the 'MonocleClient'


### PR DESCRIPTION
This change enables setting https://www.openssl.org/docs/man1.1.1/man1/ciphers.html

Fixes #822