### PR TITLE
[api] fix missusage of author filter for TOP_COMMENTED/TOP_REVIEWED queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - [webui] avoid failure to access a group with url encoded name.
+- [api] wrong author filtering for TOP_REVIEWED_AUTHORS and TOP_COMMENTED_AUTHORS queries.
 
 ## [1.4.0] - 2022-01-31
 

--- a/haskell/src/Monocle/Backend/Queries.hs
+++ b/haskell/src/Monocle/Backend/Queries.hs
@@ -677,12 +677,12 @@ getMostActiveAuthorByChangeCommented limit =
 
 getMostReviewedAuthor :: QueryMonad m => Word32 -> m TermsResultWTH
 getMostReviewedAuthor limit =
-  withFlavor (QueryFlavor OnAuthor CreatedAt) $
+  withFlavor (QueryFlavor Author CreatedAt) $
     getDocTypeTopCountByField (EChangeReviewedEvent :| []) "on_author.muid" (Just limit)
 
 getMostCommentedAuthor :: QueryMonad m => Word32 -> m TermsResultWTH
 getMostCommentedAuthor limit =
-  withFlavor (QueryFlavor OnAuthor CreatedAt) $
+  withFlavor (QueryFlavor Author CreatedAt) $
     getDocTypeTopCountByField (EChangeCommentedEvent :| []) "on_author.muid" (Just limit)
 
 -- | peer strength authors


### PR DESCRIPTION
Those queries list the most commented or reviewed change authors, but
when an author filter is specified we expect to get filtered on the
comment or review events created by the filtered author.

In other words, by filtering on an author we want to see on which change
authors a reviewer or commenter have been the most active.