### PR TITLE
[crawler] Honor the TLS_NO_VERIFY flag for gerrit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 
 - [webui] avoid failure to access a group with url encoded name.
 - [api] wrong author filtering for TOP_REVIEWED_AUTHORS and TOP_COMMENTED_AUTHORS queries.
+- [crawler] honor the "TLS_NO_VERIFY" environment variable for the Gerrit crawler.
 
 ## [1.4.0] - 2022-01-31
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ docker-compose logs -f
 
 You should be able to access the web UI at <http://localhost:8080>.
 
-See [Troubleshooting](#troubleshooting) section if needed. 
+See [Troubleshooting](#troubleshooting) section if needed.
 
 
 ## Configuration
@@ -207,7 +207,6 @@ A Gerrit provider settings
     # Optional settings
     gerrit_login: monocle
     gerrit_password: GERRIT_PASSWORD
-    gerrit_url_insecure: true
     gerrit_prefix: opendev/
 ```
 
@@ -217,8 +216,6 @@ A Gerrit provider settings
 `gerrit_login` might be specified to authenticate on the provider API.
 `gerrit_password`might be specified to use an alternate environment variable name to look for the
 password. Default is "GERRIT_PASSWORD"
-
-`gerrit_url_insecure` could be set to true to prevent HTTP certificate check.
 
 `gerrit_prefix` might be set to configure the crawler to prepend the repository name with a prefix.
 
@@ -440,6 +437,8 @@ Crawler default ciphers can be restrictive and not able to work with some load b
 server advertising an unsupported cipher. If you experience `wrong signature type` errors in the
 crawler container, you should consider changing ciphers using the `TLS_CIPHER` environment variable
 in your docker-compose configuration file. You can find [additional information](https://fedoraproject.org/wiki/Changes/StrongCryptoSettings2) on Fedora changelog.
+
+To disable TLS verification, use the `TLS_NO_VERIFY` environment variable.
 
 ## Components
 

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ server advertising an unsupported cipher. If you experience `wrong signature typ
 crawler container, you should consider changing ciphers using the `TLS_CIPHER` environment variable
 in your docker-compose configuration file. You can find [additional information](https://fedoraproject.org/wiki/Changes/StrongCryptoSettings2) on Fedora changelog.
 
-To disable TLS verification, use the `TLS_NO_VERIFY` environment variable.
+To disable TLS verification, set the `TLS_NO_VERIFY` environment variable to `1`.
 
 ## Components
 

--- a/haskell/monocle.cabal
+++ b/haskell/monocle.cabal
@@ -119,7 +119,7 @@ library
                      , fakedata                   >= 1.0
                      , fast-logger
                      , foldl
-                     , gerrit                     >= 0.1.4
+                     , gerrit                     >= 0.1.5
                      , gitrev                     >= 1.3.1
                      , hashtables                 >= 1.2
                      , http-client                >= 0.6

--- a/haskell/src/Lentille/Gerrit.hs
+++ b/haskell/src/Lentille/Gerrit.hs
@@ -33,6 +33,7 @@ import Gerrit.Data.Project (GerritProjectsMessage)
 import qualified Google.Protobuf.Timestamp as T
 import Lentille
 import qualified Monocle.Change as C
+import Monocle.Client (mkManager)
 import Monocle.Prelude hiding (all, id)
 import qualified Monocle.Project as P
 import qualified Network.URI as URI
@@ -55,10 +56,15 @@ instance MonadGerrit LentilleM where
   queryChanges env count queries = liftIO . queryChanges env count queries
 
 instance MonadGerrit IO where
-  getGerritClient url Nothing = G.getClient url Nothing
-  getGerritClient url (Just (user, Secret password)) = G.getClient url $ Just (user, password)
+  getGerritClient url Nothing = getClient url Nothing
+  getGerritClient url (Just (user, Secret password)) = getClient url $ Just (user, password)
   getProjects env count query startM = G.getProjects count query startM (client env)
   queryChanges env count queries startM = G.queryChanges count queries startM (client env)
+
+getClient :: Text -> Maybe (Text, Text) -> IO G.GerritClient
+getClient url auth = do
+  manager <- mkManager
+  pure $ G.getClientWithManager manager url auth
 
 data GerritEnv = GerritEnv
   { -- | The Gerrit connexion client

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -91,7 +91,7 @@ let
               url =
                 "https://softwarefactory-project.io/r/software-factory/gerrit-haskell";
               ref = "master";
-              rev = "e0efd6e2b645d46eca02f91ef4397307e51c1de8";
+              rev = "7ba07ed5c9da867bd566d114eb2962d7f4b90cf5";
             };
           in pkgs.haskell.lib.dontCheck (hpPrev.callCabal2nix "gerrit" src { });
 


### PR DESCRIPTION
This change removes the unsupported gerrit_url_insecure configuration
and adds support for the global TLS_NO_VERIFY flag for gerrit crawler.

Fixes: #840