### PR TITLE
feat(migrator): add new component

### DIFF
--- a/Dockerfile-migrator
+++ b/Dockerfile-migrator
@@ -1,0 +1,31 @@
+# Monocle.
+# Copyright (C) 2021 Monocle authors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# Update the builder image with:
+#  TMPDIR=/tmp/ podman build -f Dockerfile-build -t quay.io/change-metrics/builder .
+#  podman push quay.io/change-metrics/builder
+
+# base image
+FROM registry.fedoraproject.org/fedora:35
+ENV LANG=C.UTF-8
+
+RUN dnf update -y && dnf install -y ShellCheck && dnf clean all
+COPY ./migrate-action.sh .
+RUN shellcheck ./migrate-action.sh
+
+FROM registry.fedoraproject.org/fedora:35
+COPY ./migrate-action.sh .
+ENTRYPOINT ./migrate-action.sh

--- a/deployment/migrator-cronjob.yaml
+++ b/deployment/migrator-cronjob.yaml
@@ -1,0 +1,17 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: migrator
+spec:
+  jobTemplate:
+    metadata:
+      name: migrator
+    spec:
+      template:
+        spec:
+          containers:
+          - image: quay.io/change-metrics/monocle_migrator:latest
+            name: migrator
+          restartPolicy: OnFailure
+  schedule: '*/1 * * * *'
+  suspend: true

--- a/migrator/Dockerfile-migrator
+++ b/migrator/Dockerfile-migrator
@@ -1,0 +1,1 @@
+../Dockerfile-migrator

--- a/migrator/README.md
+++ b/migrator/README.md
@@ -1,0 +1,5 @@
+This container will be responsible for migrating between versions of monocle.
+
+to use DO NOT use latest, but a pinned version, and the actions here should be idempotent.
+
+this tool is primarily for the [../deployment/](deployment solution), but can be integrated back into `docker-compose`

--- a/migrator/migrate-action.sh
+++ b/migrator/migrate-action.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eEuo pipefail
+
+echo 'manual migration actions will go here'


### PR DESCRIPTION
this migrator will allow migration between versions of monocle without the need of downtime.
currently it's empty, but the code can be changed so anyone can run his migration steps on the repo
