### PR TITLE
[test] disable unused-packages when running doctests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,7 +207,7 @@ Doctest can be executed using:
 # Ensure doctest-0.20. is installed
 cabal install doctest --overwrite-policy=always
 # Run doctest through cabal
-cabal repl --with-ghc=doctest
+cabal repl --with-ghc=doctest --ghc-options=-Wno-unused-packages
 ```
 
 Or using ghcid to automatically run the test when the code changes:

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -559,7 +559,7 @@ in rec {
 
     echo "[+] Running doctests"
     export PATH=${hsPkgs.doctest_0_20_0}/bin:$PATH
-    cabal repl --with-ghc=doctest
+    cabal repl --with-ghc=doctest --ghc-options=-Wno-unused-packages
 
     # cabal haddock
     # cabal sdist


### PR DESCRIPTION
This change improves the test output by disabling the useless warning.