### PR TITLE
[cabal] cap oidc-client to at least 0.6.1

### DIFF
--- a/haskell/cabal.project
+++ b/haskell/cabal.project
@@ -10,12 +10,6 @@ source-repository-package
   location: https://github.com/kowainik/relude
   tag: 1cd9f2ebe13322007b7c3e84b6f11126e98c10fa
 
--- Pull last haskell-oidc-client master for bytestring version cap removal
-source-repository-package
-  type: git
-  location: https://github.com/krdlab/haskell-oidc-client
-  tag: 78dae84b9903038af61af87fe94112dd7aa57ebc
-
 package proto3-suite
   flags: -swagger
 

--- a/haskell/monocle.cabal
+++ b/haskell/monocle.cabal
@@ -142,7 +142,7 @@ library
                      , mtl
                      , network                    >= 3
                      , network-uri                >= 2.5
-                     , oidc-client                >= 0.6.0
+                     , oidc-client                >= 0.6.1
                      , optparse-applicative
                      , parser-combinators         >= 1.2
                      , prometheus-client          >= 1.0

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -91,7 +91,7 @@ let
             src = builtins.fetchGit {
               url = "https://github.com/krdlab/haskell-oidc-client";
               ref = "master";
-              rev = "78dae84b9903038af61af87fe94112dd7aa57ebc";
+              rev = "d00e6c52d529e7e2283f4322cf9468a6221b144d";
             };
           in pkgs.haskell.lib.dontCheck
           (hpPrev.callCabal2nix "oidc-client" src { });


### PR DESCRIPTION
This release includes a fix for dependency issue with
bytestring.

So this change remove the cabal override has the package is published
on hackage. However still not available on nix then simply update the
sha to get release 0.6.1.