### PR TITLE
[build] proto3-wire released top 1.3.0

### DIFF
--- a/haskell/cabal.project
+++ b/haskell/cabal.project
@@ -1,9 +1,3 @@
--- Pull in version for hashable-1.4
-source-repository-package
-  type: git
-  location: https://github.com/awakesecurity/proto3-wire
-  tag: 267242d7daa004e8b42e81146590865c8efe3437
-
 -- Pull last relude master for hashable-1.4
 source-repository-package
   type: git

--- a/haskell/monocle.cabal
+++ b/haskell/monocle.cabal
@@ -93,7 +93,7 @@ common codegen
                      , containers                 >= 0.6
                      , deepseq                    >= 1.4
                      , proto3-suite               >= 0.5.0
-                     , proto3-wire                >= 1.2.0
+                     , proto3-wire                >= 1.3.0
                      , text
                      , vector                     >= 0.12
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -81,7 +81,7 @@ let
             src = builtins.fetchGit {
               url = "https://github.com/awakesecurity/proto3-wire";
               ref = "master";
-              rev = "a5ed1a3bff0816cc247a1058232f3ed8a6f1e873";
+              rev = "9bf881bfc578a72ed471621d54c968f0c06b1821";
             };
           in pkgs.haskell.lib.dontCheck
           (hpPrev.callCabal2nix "proto3-wire" src { });


### PR DESCRIPTION
- Remove pinning in cabal.project
- Pin to >= 1.3.0 in monocle.cabal
- Update nix pinning (not available on our nixpkgs version)