### PR TITLE
Remove turtle pinning as proto3-wire got a new revision

### DIFF
--- a/haskell/cabal.project
+++ b/haskell/cabal.project
@@ -2,5 +2,3 @@ package proto3-suite
   flags: -swagger
 
 packages: .
-
-constraints: turtle < 1.6


### PR DESCRIPTION
A new revision on hackage has been published that should
enable us to remove the constraint.