### PR TITLE
More metrics under Metrics system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 ### Removed
 ### Fixed
 
+- [api] The self-merged count on the Activity page was incorrect and it is now properly calculated.
+
 ## [1.6.0] - 2022-06-20
 
 ### Added

--- a/haskell/src/Monocle/Backend/Documents.hs
+++ b/haskell/src/Monocle/Backend/Documents.hs
@@ -454,6 +454,7 @@ data EChangeEvent = EChangeEvent
     -- does not set any author for ChangeAbandonedEvent
     echangeeventAuthor :: Maybe Author,
     echangeeventOnAuthor :: Author,
+    echangeeventSelfMerged :: Maybe Bool,
     echangeeventBranch :: LText,
     -- Set labels as a Maybe type because existing indexes do not have the event docs with labels
     -- TODO: implement a migration procedure in the Janitor and remove the 'Maybe' from this value

--- a/haskell/src/Monocle/Backend/Provisioner.hs
+++ b/haskell/src/Monocle/Backend/Provisioner.hs
@@ -128,23 +128,24 @@ fakeChange from' to = do
 
 fakeChangeEvent :: UTCTime -> UTCTime -> Faker.Fake EChangeEvent
 fakeChangeEvent from' to = do
-  let echangeeventId = ""
-  let echangeeventNumber = 0
   echangeeventType <- Faker.Combinators.elements [minBound .. maxBound]
-  let echangeeventChangeId = ""
-  let echangeeventUrl = ""
-  let echangeeventChangedFiles = []
-  let echangeeventRepositoryPrefix = ""
-  let echangeeventRepositoryShortname = ""
-  let echangeeventRepositoryFullname = ""
-  let echangeeventAuthor = Nothing
   echangeeventOnAuthor <- fakeAuthor
-  let echangeeventBranch = ""
   echangeeventCreatedAt <- dropTime <$> Faker.DateTime.utcBetween from' to
   echangeeventOnCreatedAt <- dropTime <$> Faker.DateTime.utcBetween echangeeventCreatedAt to
-  let echangeeventApproval = Nothing
-  let echangeeventTasksData = Nothing
-  let echangeeventLabels = Just []
+  let echangeeventId = ""
+      echangeeventNumber = 0
+      echangeeventChangeId = ""
+      echangeeventUrl = ""
+      echangeeventChangedFiles = []
+      echangeeventRepositoryPrefix = ""
+      echangeeventRepositoryShortname = ""
+      echangeeventRepositoryFullname = ""
+      echangeeventAuthor = Nothing
+      echangeeventSelfMerged = Nothing
+      echangeeventBranch = ""
+      echangeeventApproval = Nothing
+      echangeeventTasksData = Nothing
+      echangeeventLabels = Just []
   pure $ EChangeEvent {..}
 
 fakeTaskId :: Faker.Fake Text

--- a/haskell/src/Monocle/Backend/Queries.hs
+++ b/haskell/src/Monocle/Backend/Queries.hs
@@ -294,12 +294,6 @@ changeState state' =
     BH.TermQuery (BH.Term "state" $ from state') Nothing
   ]
 
-selfMerged :: [BH.Query]
-selfMerged =
-  [ BH.TermQuery (BH.Term "type" "Change") Nothing,
-    BH.TermQuery (BH.Term "self_merged" "true") Nothing
-  ]
-
 testIncluded :: BH.Query
 testIncluded =
   BH.QueryRegexpQuery $
@@ -651,21 +645,6 @@ openChangesCount = withFilter (changeState EChangeOpen) (withoutDate countDocs)
   where
     withoutDate = withModified Q.dropDate
 
-mergedChangesCount :: QueryMonad m => m Count
-mergedChangesCount =
-  withFilter
-    [documentType EChangeMergedEvent]
-    (withFlavor (QueryFlavor OnAuthor CreatedAt) countDocs)
-
-abandonedChangesCount :: QueryMonad m => m Count
-abandonedChangesCount =
-  withFilter
-    [documentType EChangeAbandonedEvent]
-    (withFlavor (QueryFlavor OnAuthor CreatedAt) countDocs)
-
-selfMergedChangeCount :: QueryMonad m => m Count
-selfMergedChangeCount = withFilter selfMerged countDocs
-
 -- | The repos_summary query
 getRepos :: QueryMonad m => m TermsResultWTH
 getRepos =
@@ -697,15 +676,14 @@ getReposSummary = do
 
     getRepoSummary fullname = withRepo fullname $ do
       -- Prepare the queries
-      let eventQF = withFlavor (QueryFlavor OnAuthor CreatedAt)
-          changeQF = withFlavor (QueryFlavor Author UpdatedAt)
+      let changeQF = withFlavor (QueryFlavor Author UpdatedAt)
 
       -- Count the events
-      createdChanges <- withFilter [documentType EChangeCreatedEvent] (eventQF countDocs)
+      createdChanges <- wordToCount <$> runMetric metricChangesCreatedCount
       updatedChanges <- withFilter (changeState EChangeOpen) (changeQF countDocs)
-      mergedChanges <- mergedChangesCount
+      mergedChanges <- wordToCount <$> runMetric metricChangesMergedCount
       openChanges <- openChangesCount
-      abandonedChanges <- abandonedChangesCount
+      abandonedChanges <- wordToCount <$> runMetric metricChangesAbandonedCount
 
       pure $ RepoSummary {..}
 
@@ -1057,13 +1035,13 @@ getLifecycleStats = do
         <*> pure (countToWord created)
     pure (created, Just stats)
 
-  merged <- mergedChangesCount
-  selfMerged' <- selfMergedChangeCount
-  abandoned <- abandonedChangesCount
+  merged <- wordToCount <$> runMetric metricChangesMergedCount
+  selfMerged <- runMetric metricChangesSelfMergedCount
+  abandoned <- wordToCount <$> runMetric metricChangesAbandonedCount
 
   let lifecycleStatsMerged = countToWord merged
-      lifecycleStatsSelfMerged = countToWord selfMerged'
-      lifecycleStatsSelfMergedRatio = selfMerged' `ratioF` merged
+      lifecycleStatsSelfMerged = selfMerged
+      lifecycleStatsSelfMergedRatio = wordToCount selfMerged `ratioF` merged
       lifecycleStatsAbandoned = countToWord abandoned
 
   lifecycleStatsTtmMean <- runMetric metricTimeToMerge
@@ -1217,6 +1195,56 @@ data Metric m a = Metric
 
 instance Functor m => Functor (Metric m) where
   fmap f x = Metric (metricInfo x) (f <$> runMetric x)
+
+changeEventCount :: QueryMonad m => MetricInfo -> EDocType -> Metric m Word32
+changeEventCount mi dt =
+  Metric mi (countToWord <$> compute)
+  where
+    compute = withFilter [documentType dt] (eventQF countDocs)
+    eventQF = withFlavor (QueryFlavor OnAuthor CreatedAt)
+
+metricChangesCreatedCount :: QueryMonad m => Metric m Word32
+metricChangesCreatedCount = changeEventCount mi EChangeCreatedEvent
+  where
+    mi =
+      MetricInfo
+        "changes_created_count"
+        "Changes created count"
+        "The count of changes created"
+
+metricChangesMergedCount :: QueryMonad m => Metric m Word32
+metricChangesMergedCount = changeEventCount mi EChangeMergedEvent
+  where
+    mi =
+      MetricInfo
+        "changes_merged_count"
+        "Changes merged count"
+        "The count of changes merged"
+
+metricChangesAbandonedCount :: QueryMonad m => Metric m Word32
+metricChangesAbandonedCount = changeEventCount mi EChangeAbandonedEvent
+  where
+    mi =
+      MetricInfo
+        "changes_abandoned_count"
+        "Changes abandoned count"
+        "The count of changes abandoned"
+
+metricChangesSelfMergedCount :: QueryMonad m => Metric m Word32
+metricChangesSelfMergedCount =
+  Metric
+    ( MetricInfo
+        "changes_self_merged_count"
+        "Changes self merged count"
+        "The count of changes self merged"
+    )
+    (countToWord <$> compute)
+  where
+    compute = withFilter selfMerged countDocs
+    selfMerged =
+      [ BH.TermQuery (BH.Term "type" "Change") Nothing,
+        BH.TermQuery (BH.Term "self_merged" "true") Nothing
+      ]
 
 metricTimeToMerge :: QueryMonad m => Metric m Float
 metricTimeToMerge =

--- a/haskell/src/Monocle/Backend/Queries.hs
+++ b/haskell/src/Monocle/Backend/Queries.hs
@@ -1242,7 +1242,7 @@ metricChangesSelfMergedCount =
   where
     compute = withFilter selfMerged countDocs
     selfMerged =
-      [ BH.TermQuery (BH.Term "type" "Change") Nothing,
+      [ documentType EChangeMergedEvent,
         BH.TermQuery (BH.Term "self_merged" "true") Nothing
       ]
 

--- a/haskell/src/Monocle/Prelude.hs
+++ b/haskell/src/Monocle/Prelude.hs
@@ -92,6 +92,7 @@ module Monocle.Prelude
     Count,
     countToWord,
     countToDeci,
+    wordToCount,
     naturalToCount,
 
     -- * time
@@ -416,6 +417,9 @@ newtype Count = MkCount Word32
 
 countToWord :: Count -> Word32
 countToWord (MkCount x) = x
+
+wordToCount :: Word32 -> Count
+wordToCount = MkCount
 
 countToDeci :: Count -> Deci
 countToDeci (MkCount x) = fromInteger (toInteger x)

--- a/haskell/src/Tests.hs
+++ b/haskell/src/Tests.hs
@@ -285,7 +285,8 @@ monocleBackendQueriesTests =
       testCase "Test Janitor wipe crawler" testJanitorWipeCrawler,
       testCase "Test Janitor update idents" testJanitorUpdateIdents,
       testCase "Test Config Index initialization" testEnsureConfig,
-      testCase "Test Config Upgrade to version 1" testUpgradeConfigV1
+      testCase "Test Config Upgrade to version 1" testUpgradeConfigV1,
+      testCase "Test Config Upgrade to version 3" testUpgradeConfigV3
     ]
 
 monocleSearchLanguage :: TestTree


### PR DESCRIPTION
Part of the implementation of #847

This change includes 4 more simple metrics into the new Metrics system.
Furthermore during the migration of the self merged metric I've figured out that the metrics must rely on the Change Merged Event and not on the Change object. Thus this changes brings a fix for this and a schema migration to add self-merged attribute to ChangeMergedEvent.

