### PR TITLE
nix: export executables

### DIFF
--- a/.github/workflows/ci.dhall
+++ b/.github/workflows/ci.dhall
@@ -19,6 +19,11 @@ in  { Nix =
                 }
               ]
           )
+          [ mk.GithubActions.Step::{
+            , name = Some "Build the project"
+            , run = Some "nix build --no-link ./haskell?submodules=1 --impure"
+            }
+          ]
     , Web =
         mk.makeNPM
           [ mk.GithubActions.Step::{

--- a/.github/workflows/mkCI.dhall
+++ b/.github/workflows/mkCI.dhall
@@ -127,6 +127,7 @@ in  { GithubActions
     , makeNix =
         \(cache-name : Text) ->
         \(steps : List GithubActions.Step.Type) ->
+        \(build-steps : List GithubActions.Step.Type) ->
           let boot =
                 \(name : Text) ->
                   [ checkout-step
@@ -156,6 +157,11 @@ in  { GithubActions
                     , name = Some "api-tests"
                     , runs-on = GithubActions.RunsOn.Type.ubuntu-latest
                     , steps = boot cache-name # steps
+                    }
+                  , build = GithubActions.Job::{
+                    , name = Some "build"
+                    , runs-on = GithubActions.RunsOn.Type.ubuntu-latest
+                    , steps = boot cache-name # build-steps
                     }
                   }
               }

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -29,6 +29,22 @@ jobs:
         run: nix-build --no-out-link --attr monocle-light.env
       - name: Run Test
         run: "cd haskell; nix-shell --pure --attr ci-shell ../nix/default.nix --command 'env MONOCLE_ELASTIC_URL=http://localhost:9200 monocle-ci-run'"
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/checkout@v2.4.0"
+        with:
+          submodules: 'true'
+      - uses: "cachix/install-nix-action@v15"
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: "cachix/cachix-action@v10"
+        with:
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          name: change-metrics
+      - name: Build the project
+        run: "nix build --no-link ./haskell?submodules=1 --impure"
 name: Nix
 on:
   pull_request: {}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,12 @@ If you have not installed nix-shell follow the instructions [here](https://nixos
 
 You can configure the project [cachix](https://cachix.org) binary cache with this command: `nix-shell -p cachix --command "cachix use change-metrics"`.
 
+You can also use the cachix store directly, for example to run the monocle command:
+
+```ShellSession
+nix run ./haskell --option binary-caches "https://cache.nixos.org https://change-metrics.cachix.org" --option trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= change-metrics.cachix.org-1:dCe8jx9vptiF6DCdZ5y2QouvDsxgFRZnbHowhPnS4C0=" --impure
+```
+
 
 #### ElasticSearch
 

--- a/haskell/flake.nix
+++ b/haskell/flake.nix
@@ -6,5 +6,12 @@
 
   outputs = { self, nixpkgs }:
     let legacy = import ../nix/default.nix { nixpkgsPath = nixpkgs; };
-    in { devShell."x86_64-linux" = legacy.shell; };
+    in {
+      devShell."x86_64-linux" = legacy.shell;
+      packages."x86_64-linux".default = legacy.monocle-exe;
+      apps."x86_64-linux".default = {
+        type = "app";
+        program = "${legacy.monocle-exe}/bin/monocle";
+      };
+    };
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -622,6 +622,8 @@ in rec {
   # dontCheck because doctests are not working...
   monocle = pkgs.haskell.lib.dontCheck hsPkgs.monocle;
 
+  monocle-exe = pkgs.haskell.lib.justStaticExecutables hsPkgs.monocle;
+
   services = pkgs.stdenv.mkDerivation {
     name = "monocle-services";
     buildInputs = base-req ++ services-req;


### PR DESCRIPTION
This change publishes the monocle executable to the cachix store.