### PR TITLE
GHA: Ensure same version of nodejs than on NIX

### DIFF
--- a/.github/workflows/mkCI.dhall
+++ b/.github/workflows/mkCI.dhall
@@ -175,7 +175,7 @@ in  { GithubActions
                 [ checkout-step
                 , GithubActions.Step::{
                   , uses = Some "actions/setup-node@v2"
-                  , `with` = Some (toMap { node-version = "16" })
+                  , `with` = Some (toMap { node-version = "16.15" })
                   }
                 ]
 

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -6,7 +6,7 @@ jobs:
       - uses: "actions/checkout@v2.4.0"
       - uses: "actions/setup-node@v2"
         with:
-          node-version: '16'
+          node-version: '16.15'
       - name: Install npm packages
         run: "sudo apt-get install git; cd web; npm install --legacy-peer-deps"
       - name: Run NPM tests


### PR DESCRIPTION
To unlock https://github.com/change-metrics/monocle/pull/917