### PR TITLE
Integrate hspkgs overlay for haskell dependency

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -6,17 +6,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1659992185,
-        "narHash": "sha256-gBo1GnJ9uo1xXbzqD2lWc6zzB0pxhTTdD9BvoWbuEqA=",
+        "lastModified": 1660059949,
+        "narHash": "sha256-Fa3L/MQLZFbvd9z8TsqBwAPTGqHjQkntEbXHNdvQ760=",
         "owner": "podenv",
         "repo": "hspkgs",
-        "rev": "06a0ec4e9aef30318ddd10265a213e7563a728d3",
+        "rev": "24d2028871584f71313ac06e23ef143db61aea34",
         "type": "github"
       },
       "original": {
         "owner": "podenv",
         "repo": "hspkgs",
-        "rev": "06a0ec4e9aef30318ddd10265a213e7563a728d3",
+        "rev": "24d2028871584f71313ac06e23ef143db61aea34",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,64 @@
 {
   "nodes": {
+    "hspkgs": {
+      "inputs": {
+        "nixGL": "nixGL",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1659984985,
+        "narHash": "sha256-PfIN3bx265K9QNnTiSPIwX1uYV5fbpdhxn97+jmUiMc=",
+        "owner": "podenv",
+        "repo": "hspkgs",
+        "rev": "c97192fe75d7f9df9fae97b0840cf0ed777e23ce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "podenv",
+        "repo": "hspkgs",
+        "rev": "c97192fe75d7f9df9fae97b0840cf0ed777e23ce",
+        "type": "github"
+      }
+    },
+    "nixGL": {
+      "inputs": {
+        "nixpkgs": [
+          "hspkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1656321324,
+        "narHash": "sha256-Sz0uWspqvshGFbT+XmRVVayuW514rNNLLvrre8jBLLU=",
+        "owner": "guibou",
+        "repo": "nixGL",
+        "rev": "047a34b2f087e2e3f93d43df8e67ada40bf70e5c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "guibou",
+        "repo": "nixGL",
+        "rev": "047a34b2f087e2e3f93d43df8e67ada40bf70e5c",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1659891956,
+        "narHash": "sha256-ymyDKkXQs5Z9+ezMutHmnDqztYmDTFZEsFuaPeBzkMI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "00d73d5385b63e868bd11282fb775f6fe4921fb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "00d73d5385b63e868bd11282fb775f6fe4921fb5",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1652483617,
         "narHash": "sha256-Jxyn3uXFr5LdZNNiippI/obtLXAVBM18uVfiKVP4j9Q=",
@@ -18,7 +76,8 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "hspkgs": "hspkgs",
+        "nixpkgs": "nixpkgs_2"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -6,17 +6,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1659984985,
-        "narHash": "sha256-PfIN3bx265K9QNnTiSPIwX1uYV5fbpdhxn97+jmUiMc=",
+        "lastModified": 1659992185,
+        "narHash": "sha256-gBo1GnJ9uo1xXbzqD2lWc6zzB0pxhTTdD9BvoWbuEqA=",
         "owner": "podenv",
         "repo": "hspkgs",
-        "rev": "c97192fe75d7f9df9fae97b0840cf0ed777e23ce",
+        "rev": "06a0ec4e9aef30318ddd10265a213e7563a728d3",
         "type": "github"
       },
       "original": {
         "owner": "podenv",
         "repo": "hspkgs",
-        "rev": "c97192fe75d7f9df9fae97b0840cf0ed777e23ce",
+        "rev": "06a0ec4e9aef30318ddd10265a213e7563a728d3",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,12 +5,15 @@
   inputs = {
     nixpkgs.url =
       "github:NixOS/nixpkgs/ed014c27f4d0ca772fb57d3b8985b772b0503bbd";
+    hspkgs.url =
+      "github:podenv/hspkgs/c97192fe75d7f9df9fae97b0840cf0ed777e23ce";
   };
 
-  outputs = { self, nixpkgs }:
+  outputs = { self, nixpkgs, hspkgs }:
     let
       legacy = import ./nix/default.nix {
         nixpkgsPath = nixpkgs;
+        hspkgs = hspkgs.pkgs;
         self = self;
       };
     in {

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     nixpkgs.url =
       "github:NixOS/nixpkgs/ed014c27f4d0ca772fb57d3b8985b772b0503bbd";
     hspkgs.url =
-      "github:podenv/hspkgs/c97192fe75d7f9df9fae97b0840cf0ed777e23ce";
+      "github:podenv/hspkgs/06a0ec4e9aef30318ddd10265a213e7563a728d3";
   };
 
   outputs = { self, nixpkgs, hspkgs }:

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     nixpkgs.url =
       "github:NixOS/nixpkgs/ed014c27f4d0ca772fb57d3b8985b772b0503bbd";
     hspkgs.url =
-      "github:podenv/hspkgs/06a0ec4e9aef30318ddd10265a213e7563a728d3";
+      "github:podenv/hspkgs/24d2028871584f71313ac06e23ef143db61aea34";
   };
 
   outputs = { self, nixpkgs, hspkgs }:

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -462,10 +462,8 @@ in rec {
   fast-ci-run = mkRun "fast-ci" fast-ci-commands;
 
   reformat-run = mkRun "reformat" ''
-    # This needs apply-refact, but it doesn't build in our package set and that would requires pulling an extra ghc.
-    # Let's try again next time we bump nixpkgs.
-    # echo "[+] Apply hlint suggestions"
-    # ${hlint ''--refactor --refactor-options="-i"''}
+    echo "[+] Apply hlint suggestions"
+    find src/ -name "*hs" -exec ${hspkgs.hlint}/bin/hlint -XQuasiQuotes --refactor --refactor-options="-i" {} \;
 
     echo "[+] Reformat with ormolu"
     ${ormolu "inplace"}
@@ -487,6 +485,7 @@ in rec {
 
     buildInputs = [
       hspkgs.hlint
+      hspkgs.apply-refact
       hspkgs.ghcid
       hspkgs.haskell-language-server
       hsPkgs.doctest

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,194 +1,76 @@
-{ elasticsearch-port ? 19200, nixpkgsPath, self }:
+{ elasticsearch-port ? 19200, nixpkgsPath, hspkgs, self }:
 let
   nixpkgsSrc = import nixpkgsPath;
-
-  # update haskell dependencies
-  compilerVersion = "922";
-  compiler = "ghc" + compilerVersion;
 
   mk-morpheus-lib = hpPrev: name:
     let
       morpheus-graphql-src = pkgs.fetchFromGitHub {
         owner = "morpheusgraphql";
         repo = "morpheus-graphql";
-        # Fix for bytestring-0.11, proposed in https://github.com/morpheusgraphql/morpheus-graphql/pull/723
         rev = "df3a4b0d11b53de3ddf3b43966e0242877541e50";
         sha256 = "sha256-rrDWIYmY9J9iPI/lSuflyyxapAXyuHbLP86awH33mzo=";
       };
     in (hpPrev.callCabal2nix "morpheus-graphql-${name}"
       "${morpheus-graphql-src}/morpheus-graphql-${name}" { });
 
-  mk-servant-lib = hpPrev: name:
-    let
-      # Use direct source because nixpkgs somehow can't fetch
-      servant-src = builtins.fetchGit {
-        url = "https://github.com/haskell-servant/servant";
-        ref = "master";
-        rev = "c19ed0fb925fbe62365adcaf286c00c497adf8fb";
+  # Add monocle and patch broken dependency to the haskell package set
+  haskellExtend = hpFinal: hpPrev: {
+    monocle = (hpPrev.callCabal2nix "monocle" self { }).overrideAttrs
+      (_: { MONOCLE_COMMIT = builtins.getEnv "MONOCLE_COMMIT"; });
+
+    # data-diverse is presently marked as broken because the test don't pass.
+    data-diverse = pkgs.haskell.lib.dontCheck
+      (pkgs.haskell.lib.overrideCabal hpPrev.data-diverse { broken = false; });
+
+    # proto3-wire test needs bytestring-0.11, though even with the patch the test does not pass.
+    proto3-wire = pkgs.haskell.lib.dontCheck hpPrev.proto3-wire;
+
+    # proto3-suite doesn't work with old swagger, so we disable the flag
+    # and the test doesn't pass in nix.
+    proto3-suite = pkgs.haskell.lib.dontCheck
+      (pkgs.haskell.lib.disableCabalFlag hpPrev.proto3-suite "swagger");
+
+    # criterion test sometime hangs
+    criterion = pkgs.haskell.lib.dontCheck hpPrev.criterion;
+
+    # upgrade to bloodhound 0.20 needs some work
+    bloodhound = pkgs.haskell.lib.overrideCabal hpPrev.bloodhound {
+      version = "0.19.1.0";
+      sha256 = "sha256-QEN1wOLLUEsDKAbgz8ex0wfK/duNytvRYclwkBj/1G0=";
+    };
+
+    # upgrade to latest morpheus needs some work
+    morpheus-graphql-tests = mk-morpheus-lib hpPrev "tests";
+    morpheus-graphql-core = mk-morpheus-lib hpPrev "core";
+    morpheus-graphql-code-gen = mk-morpheus-lib hpPrev "code-gen";
+    morpheus-graphql-client = mk-morpheus-lib hpPrev "client";
+
+    # gerrit needs a fix for bytestring>0.11
+    gerrit = let
+      src = builtins.fetchGit {
+        url =
+          "https://softwarefactory-project.io/r/software-factory/gerrit-haskell";
+        ref = "refs/changes/41/24541/1";
+        rev = "c0c337bccb35e7d94e6125ab034cfcc9efe68476";
       };
-    in (hpPrev.callCabal2nix "sevant${name}" "${servant-src}/servant${name}"
-      { });
-
-  overlays = [
-    (final: prev: {
-      myHaskellPackages = prev.haskell.packages.${compiler}.override {
-        overrides = hpFinal: hpPrev: {
-          # For proto3-suite:
-          range-set-list = pkgs.haskell.lib.dontCheck
-            (pkgs.haskell.lib.overrideCabal hpPrev.range-set-list {
-              broken = false;
-            });
-          data-diverse = pkgs.haskell.lib.dontCheck
-            (pkgs.haskell.lib.overrideCabal hpPrev.data-diverse {
-              broken = false;
-            });
-          # Test suite hang
-          servant-auth-server = pkgs.haskell.lib.dontCheck
-            (pkgs.haskell.lib.overrideCabal hpPrev.servant-auth-server {
-              broken = false;
-            });
-          # HEAD is needed for bytestring-0.11 and ghc-9.2 base
-          proto3-suite = let
-            src = builtins.fetchGit {
-              url = "https://github.com/awakesecurity/proto3-suite";
-              ref = "master";
-              rev = "5456b633ba7283ff11adcd457744b54ebdd28a37";
-            };
-            base = pkgs.haskell.lib.dontCheck
-              (hpPrev.callCabal2nix "proto3-suite" src { });
-          in pkgs.haskell.lib.disableCabalFlag base "swagger";
-
-          # HEAD is needed for bytestring-0.11
-          proto3-wire = let
-            src = builtins.fetchGit {
-              url = "https://github.com/awakesecurity/proto3-wire";
-              ref = "master";
-              rev = "a5ed1a3bff0816cc247a1058232f3ed8a6f1e873";
-            };
-          in pkgs.haskell.lib.dontCheck
-          (hpPrev.callCabal2nix "proto3-wire" src { });
-
-          oidc-client = pkgs.haskell.lib.overrideCabal hpPrev.oidc-client {
-            version = "0.6.1.0";
-            sha256 = "sha256-PtzYvIs6gXO40JHMElNH/i+kxMSZephJMkkJTGCzEkI=";
-          };
-
-          jose-jwt = (pkgs.haskell.lib.overrideCabal hpPrev.jose-jwt {
-            broken = false;
-          });
-
-          # Hackage version does not build without a bump
-          text-time = (pkgs.haskell.lib.overrideCabal hpPrev.text-time {
-            broken = false;
-            src = builtins.fetchGit {
-              url = "https://github.com/klangner/text-time.git";
-              ref = "master";
-              rev = "1ff65c2c8845e3fdd99900054f0596818a95c316";
-            };
-          });
-
-          # ghc-9.2 fix proposed in https://github.com/byteverse/json-syntax/pull/11
-          # and https://github.com/byteverse/json-syntax/pull/13
-          json-syntax = let
-            src = builtins.fetchGit {
-              url = "https://github.com/TristanCacqueray/json-syntax";
-              ref = "ghc-9.2-integration";
-              rev = "f54325b2c601b962cfb078c2295b09a0780d7313";
-            };
-          in (pkgs.haskell.lib.dontCheck
-            (hpPrev.callCabal2nix "bytebuild" src { }));
-
-          # ghc-9.2 fix proposed in: https://github.com/byteverse/bytesmith/pull/22
-          bytesmith = let
-            src = builtins.fetchGit {
-              url = "https://github.com/teto/bytesmith";
-              ref = "ghc92";
-              rev = "dfdf6922e118932ba7d671e05a5b65998349cee8";
-            };
-          in (hpPrev.callCabal2nix "bytesmith" src { });
-
-          weeder = let
-            src = builtins.fetchGit {
-              url = "https://github.com/ocharles/weeder";
-              ref = "master";
-              rev = "c58ed2a8c66dcf0b469f8343efb6b6f61c7c40f3";
-            };
-          in (hpPrev.callCabal2nix "weeder" src { });
-
-          # Master version for ghc-9.2
-          bytebuild = let
-            src = builtins.fetchGit {
-              url = "https://github.com/byteverse/bytebuild";
-              ref = "master";
-              rev = "dde5a9b07d03f5a9c33eba6d63ca0140ab6f406e";
-            };
-          in (pkgs.haskell.lib.dontCheck
-            (hpPrev.callCabal2nix "bytebuild" src { }));
-
-          # ghc-9.2 fix proposed: https://github.com/andrewthad/scientific-notation/pull/4
-          scientific-notation = let
-            src = builtins.fetchGit {
-              url = "https://github.com/andrewthad/scientific-notation";
-              ref = "master";
-              rev = "0076fe9ed83e70ce068962fbd1b49d475af7a7f2";
-            };
-          in (pkgs.haskell.lib.dontCheck
-            (hpPrev.callCabal2nix "scientific-notation" src { }));
-
-          # nixpkgs somehow doesn't fetch, use direct src
-          servant = mk-servant-lib hpPrev "";
-          servant-foreign = mk-servant-lib hpPrev "-foreign";
-          servant-server = mk-servant-lib hpPrev "-server";
-
-          # nixpkgs version are broken, use direct src
-          morpheus-graphql-tests = mk-morpheus-lib hpPrev "tests";
-          morpheus-graphql-core = mk-morpheus-lib hpPrev "core";
-          morpheus-graphql-code-gen = mk-morpheus-lib hpPrev "code-gen";
-          morpheus-graphql-client = mk-morpheus-lib hpPrev "client";
-
-          gerrit = let
-            src = builtins.fetchGit {
-              url =
-                "https://softwarefactory-project.io/r/software-factory/gerrit-haskell";
-              ref = "refs/changes/41/24541/1";
-              rev = "c0c337bccb35e7d94e6125ab034cfcc9efe68476";
-            };
-          in pkgs.haskell.lib.dontCheck (hpPrev.callCabal2nix "gerrit" src { });
-
-          # Relude needs head for ghc-9.2
-          relude = (pkgs.haskell.lib.overrideCabal hpPrev.relude {
-            broken = false;
-            src = builtins.fetchGit {
-              url = "https://github.com/kowainik/relude";
-              ref = "main";
-              rev = "fcb32257a37e34a48f70ddd55424394de4bb025c";
-            };
-          });
-
-          monocle = (hpPrev.callCabal2nix "monocle" self { }).overrideAttrs
-            (_: { MONOCLE_COMMIT = builtins.getEnv "MONOCLE_COMMIT"; });
-        };
-      };
-
-    })
-  ];
+    in pkgs.haskell.lib.dontCheck (hpPrev.callCabal2nix "gerrit" src { });
+  };
 
   # create the main package set without options
-  pkgs = nixpkgsSrc {
-    inherit overlays;
-    system = "x86_64-linux";
-  };
+  pkgs = nixpkgsSrc { system = "x86_64-linux"; };
   pkgsNonFree = nixpkgsSrc {
     system = "x86_64-linux";
     config.allowUnfree = true;
   };
+  # final haskell set, see: https://github.com/NixOS/nixpkgs/issues/25887
+  hsPkgs = hspkgs.hspkgs.extend haskellExtend;
 
   # manually adds build dependencies for benchmark and codegen that are not managed by cabal2nix
   addExtraDeps = drv:
     pkgs.haskell.lib.addBuildDepends drv ([
-      pkgs.myHaskellPackages.criterion
-      pkgs.myHaskellPackages.casing
-      pkgs.myHaskellPackages.language-protobuf
+      hsPkgs.criterion
+      hsPkgs.casing
+      hsPkgs.language-protobuf
     ]);
 
   # local devel env
@@ -421,7 +303,7 @@ in rec {
   monocleGhcid = pkgs.writeScriptBin "monocle-ghcid" ''
     #!/bin/sh
     set -x
-    ${pkgs.ghcid}/bin/ghcid -c "cabal repl monocle" $*
+    ${hspkgs.ghcid}/bin/ghcid -c "cabal repl monocle" $*
   '';
 
   monocleWebStart = pkgs.writeScriptBin "monocle-web-start" ''
@@ -449,19 +331,17 @@ in rec {
   ];
 
   # define the base requirements
-  base-req = [ pkgs.bashInteractive pkgs.coreutils pkgs.gnumake ];
-  codegen-req = [ pkgs.protobuf pkgs.ocamlPackages.ocaml-protoc pkgs.glibc ]
-    ++ base-req;
-
-  # haskell dependencies for codegen
-  hsPkgs = pkgs.myHaskellPackages;
+  base-req = [ pkgs.bashInteractive hspkgs.coreutils pkgs.gnumake ];
+  codegen-req = [ pkgs.protobuf pkgs.ocamlPackages.ocaml-protoc ] ++ base-req;
 
   hs-req = [
-    pkgs.cabal-install
-    hsPkgs.ormolu
+    # Here we pull the executable from the global pkgs, not the haskell packages
+    hspkgs.cabal-install
+    hspkgs.ormolu
+    # Here we pull the proto3-suite executable from the haskell packages, not the global pkgs
     hsPkgs.proto3-suite
-    pkgs.zlib
-    hsPkgs.weeder
+    hspkgs.zlib
+    hspkgs.weeder
   ];
 
   # define javascript requirements
@@ -541,7 +421,7 @@ in rec {
     cabal test --enable-tests --flags=ci -O0 --test-show-details=direct
 
     echo "[+] Running doctests"
-    export PATH=${hsPkgs.doctest_0_20_0}/bin:$PATH
+    export PATH=${hsPkgs.doctest}/bin:$PATH
     cabal repl --with-ghc=doctest --ghc-options=-Wno-unused-packages
 
     # cabal haddock
@@ -557,12 +437,12 @@ in rec {
 
   ci-shell = hsPkgs.shellFor {
     packages = p: [ p.monocle ];
-    buildInputs = [ pkgs.cabal-install ci-run ];
+    buildInputs = [ hspkgs.cabal-install ci-run ];
   };
 
-  hlint = args: "${pkgs.hlint}/bin/hlint -XQuasiQuotes ${args} src/";
+  hlint = args: "${hspkgs.hlint}/bin/hlint -XQuasiQuotes ${args} src/";
   ormolu = mode: ''
-    ${hsPkgs.ormolu}/bin/ormolu                                 \
+    ${hspkgs.ormolu}/bin/ormolu                                 \
       -o -XPatternSynonyms -o -XTypeApplications -o -XImportQualifiedPost --mode ${mode} \
       $(find src/ -name "*.hs")
   '';
@@ -605,9 +485,12 @@ in rec {
   shell = hsPkgs.shellFor {
     packages = p: [ (addExtraDeps p.monocle) p.pretty-simple ];
 
-    buildInputs = with pkgs.myHaskellPackages;
-      [ pkgs.hlint pkgs.ghcid pkgs.haskell-language-server doctest_0_20_0 ]
-      ++ all-req ++ services-req ++ [ ci-run fast-ci-run reformat-run ];
+    buildInputs = [
+      hspkgs.hlint
+      hspkgs.ghcid
+      hspkgs.haskell-language-server
+      hsPkgs.doctest
+    ] ++ all-req ++ services-req ++ [ ci-run fast-ci-run reformat-run ];
 
     withHoogle = false;
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -44,16 +44,6 @@ let
     morpheus-graphql-core = mk-morpheus-lib hpPrev "core";
     morpheus-graphql-code-gen = mk-morpheus-lib hpPrev "code-gen";
     morpheus-graphql-client = mk-morpheus-lib hpPrev "client";
-
-    # gerrit needs a fix for bytestring>0.11
-    gerrit = let
-      src = builtins.fetchGit {
-        url =
-          "https://softwarefactory-project.io/r/software-factory/gerrit-haskell";
-        ref = "refs/changes/41/24541/1";
-        rev = "c0c337bccb35e7d94e6125ab034cfcc9efe68476";
-      };
-    in pkgs.haskell.lib.dontCheck (hpPrev.callCabal2nix "gerrit" src { });
   };
 
   # create the main package set without options

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -63,13 +63,13 @@ usage =
     usageApiEnv =
       (,,,,,,,)
         <$> envConf
-          <*> envElastic
-          <*> envApiPort
-          <*> envPublicUrl
-          <*> envTitle
-          <*> envWebAppPath
-          <*> envJwkKey
-          <*> envAdminToken
+        <*> envElastic
+        <*> envApiPort
+        <*> envPublicUrl
+        <*> envTitle
+        <*> envWebAppPath
+        <*> envJwkKey
+        <*> envAdminToken
 
     -- The Crawler entrypoint (no CLI argument).
     usageCrawler = pure $ do

--- a/src/Database/Bloodhound/Raw.hs
+++ b/src/Database/Bloodhound/Raw.hs
@@ -58,7 +58,7 @@ dispatch method url body qs = do
 
 -- | Utility function to advance in scroll result. We can use the BH library
 --   because we no longer need to support a custom raw body once we have a scroll.
-advance :: (MonadIO m, MonadBH m, MonadThrow m, FromJSON resp) => BH.ScrollId -> m (BH.SearchResult resp)
+advance :: (MonadBH m, MonadThrow m, FromJSON resp) => BH.ScrollId -> m (BH.SearchResult resp)
 advance scroll = do
   resp <- BH.advanceScroll scroll 60
   case resp of
@@ -69,7 +69,7 @@ advance scroll = do
       logText (show resp)
       error "Elastic scroll response failed"
 
-settings :: (MonadIO m, MonadBH m, ToJSON body) => BH.IndexName -> body -> m ()
+settings :: (MonadBH m, ToJSON body) => BH.IndexName -> body -> m ()
 settings (BH.IndexName index) body = do
   BH.Server s <- BH.bhServer <$> BH.getBHEnv
   let url = Text.intercalate "/" [s, index, "_settings"]
@@ -79,7 +79,7 @@ settings (BH.IndexName index) body = do
     "{\"acknowledged\":true}" -> pure ()
     _ -> error $ "Settings apply failed: " <> show resp
 
-search' :: (MonadIO m, MonadBH m, ToJSON body) => BH.IndexName -> body -> QS -> m BH.Reply
+search' :: (MonadBH m, ToJSON body) => BH.IndexName -> body -> QS -> m BH.Reply
 search' (BH.IndexName index) body qs = do
   BH.Server s <- BH.bhServer <$> BH.getBHEnv
   let url = Text.intercalate "/" [s, index, "_search"]
@@ -95,7 +95,7 @@ aesonCasing = AesonCasing.snakeCase . AesonCasing.dropFPrefix
 
 search ::
   forall resp m body.
-  (MonadIO m, MonadBH m, MonadThrow m) =>
+  (MonadBH m, MonadThrow m) =>
   (Aeson.ToJSON body, FromJSONField resp) =>
   BH.IndexName ->
   body ->
@@ -132,7 +132,7 @@ search index body scrollRequest = do
 
 -- | A special purpose search implementation that uses the faster json-syntax
 searchHit ::
-  (MonadIO m, MonadBH m) =>
+  (MonadBH m) =>
   (Aeson.ToJSON body) =>
   BH.IndexName ->
   body ->

--- a/src/Lentille/GitLab/MergeRequests.hs
+++ b/src/Lentille/GitLab/MergeRequests.hs
@@ -228,7 +228,8 @@ transformResponse host getIdentIdCB result =
                   else Nothing
               changeState = toState state
               changeOptionalDuration =
-                ( ChangeOptionalDurationDuration . from
+                ( ChangeOptionalDurationDuration
+                    . from
                     . diffTimeSec
                       ( timeToUTCTime Nothing createdAt
                       )
@@ -245,7 +246,8 @@ transformResponse host getIdentIdCB result =
               changeOptionalSelfMerged =
                 ( ChangeOptionalSelfMergedSelfMerged
                     <$> ( (==)
-                            <$> (getAuthorUsername <$> author) <*> (getMergerUsername <$> mergeUser)
+                            <$> (getAuthorUsername <$> author)
+                            <*> (getMergerUsername <$> mergeUser)
                         )
                 )
            in Change {..}

--- a/src/Lentille/GraphQL.hs
+++ b/src/Lentille/GraphQL.hs
@@ -189,7 +189,7 @@ streamFetch client@GraphClient {..} lc mkArgs StreamFetchOptParams {..} transfor
     log :: MonadLog m => Text -> m ()
     log = mLog . Log Macroscope . LogGraphQL lc
 
-    holdOnIfNeeded :: (MonadTime m, MonadLog m) => Maybe RateLimit -> m ()
+    holdOnIfNeeded :: MonadLog m => Maybe RateLimit -> m ()
     holdOnIfNeeded = mapM_ toDelay
       where
         toDelay :: (MonadLog m) => RateLimit -> m ()

--- a/src/Macroscope/Main.hs
+++ b/src/Macroscope/Main.hs
@@ -236,7 +236,9 @@ getClientBZ url token = do
   clients <- gets clientsBugzilla
   (client, newClients) <-
     mapMutate clients (url, token) . pure $
-      getBugzillaSession url $ Just $ getApikey (unSecret token)
+      getBugzillaSession url $
+        Just $
+          getApikey (unSecret token)
   modify $ \s -> s {clientsBugzilla = newClients}
   pure (url, client)
 

--- a/src/Monocle/Api/Jwt.hs
+++ b/src/Monocle/Api/Jwt.hs
@@ -91,7 +91,9 @@ instance ToMarkup LoginInUser where
     H.body $ do
       H.script
         ( H.toHtml
-            ( "localStorage.setItem('api-key','" <> liJWT <> "');"
+            ( "localStorage.setItem('api-key','"
+                <> liJWT
+                <> "');"
                 <> "window.location='"
                 <> liRedirectURI
                 <> "';"

--- a/src/Monocle/Api/Server.hs
+++ b/src/Monocle/Api/Server.hs
@@ -103,18 +103,18 @@ checkAuth auth action = do
 -- curl -XPOST -d '{"void": ""}' -H "Content-type: application/json" -H 'Authorization: Bearer <token>' http://localhost:8080/auth/whoami
 authWhoAmi :: AuthResult AuthenticatedUser -> AuthPB.WhoAmiRequest -> AppM AuthPB.WhoAmiResponse
 authWhoAmi (Authenticated au) _request =
-  pure $
-    AuthPB.WhoAmiResponse
+  pure
+    $ AuthPB.WhoAmiResponse
       . Just
       . AuthPB.WhoAmiResponseResultUid
-      $ show au
+    $ show au
 authWhoAmi _auth _request =
-  pure $
-    AuthPB.WhoAmiResponse
+  pure
+    $ AuthPB.WhoAmiResponse
       . Just
       . AuthPB.WhoAmiResponseResultError
       . Enumerated
-      $ Right AuthPB.WhoAmiErrorUnAuthorized
+    $ Right AuthPB.WhoAmiErrorUnAuthorized
 
 -- curl -XPOST -d '{"token": "admin-token"}' -H "Content-type: application/json" http://localhost:8080/auth/get
 authGetMagicJwt :: AuthResult AuthenticatedUser -> AuthPB.GetMagicJwtRequest -> AppM AuthPB.GetMagicJwtResponse
@@ -542,19 +542,22 @@ searchQuery auth request = checkAuth auth response
 
           case queryType of
             SearchPB.QueryRequest_QueryTypeQUERY_CHANGE ->
-              SearchPB.QueryResponse . Just
+              SearchPB.QueryResponse
+                . Just
                 . SearchPB.QueryResponseResultChanges
                 . SearchPB.Changes
                 . V.fromList
                 . map from
                 <$> Q.changes queryRequestOrder queryRequestLimit
             SearchPB.QueryRequest_QueryTypeQUERY_CHANGE_AND_EVENTS ->
-              SearchPB.QueryResponse . Just
+              SearchPB.QueryResponse
+                . Just
                 . SearchPB.QueryResponseResultChangeEvents
                 . toChangeEventsResult
                 <$> Q.changeEvents queryRequestChangeId queryRequestLimit
             SearchPB.QueryRequest_QueryTypeQUERY_REPOS_SUMMARY ->
-              SearchPB.QueryResponse . Just
+              SearchPB.QueryResponse
+                . Just
                 . SearchPB.QueryResponseResultReposSummary
                 . SearchPB.ReposSummary
                 . V.fromList
@@ -582,7 +585,8 @@ searchQuery auth request = checkAuth auth response
             SearchPB.QueryRequest_QueryTypeQUERY_TOP_COMMENTED_AUTHORS ->
               handleTopAuthorsQ queryRequestLimit Q.getMostCommentedAuthor
             SearchPB.QueryRequest_QueryTypeQUERY_TOP_AUTHORS_PEERS ->
-              SearchPB.QueryResponse . Just
+              SearchPB.QueryResponse
+                . Just
                 . SearchPB.QueryResponseResultAuthorsPeers
                 . SearchPB.AuthorsPeers
                 . V.fromList
@@ -595,7 +599,8 @@ searchQuery auth request = checkAuth auth response
                   SearchPB.QueryResponseResultNewAuthors $
                     toTermsCount (V.fromList $ toTTResult <$> results) 0
             SearchPB.QueryRequest_QueryTypeQUERY_CHANGES_TOPS ->
-              SearchPB.QueryResponse . Just
+              SearchPB.QueryResponse
+                . Just
                 . SearchPB.QueryResponseResultChangesTops
                 <$> Q.getChangesTops queryRequestLimit
             SearchPB.QueryRequest_QueryTypeQUERY_RATIO_COMMITS_VS_REVIEWS -> do
@@ -605,16 +610,19 @@ searchQuery auth request = checkAuth auth response
             SearchPB.QueryRequest_QueryTypeQUERY_HISTO_COMMITS -> do
               histo <- Q.runMetricTrendIntPB Q.metricChangeUpdates
               pure . SearchPB.QueryResponse . Just $
-                SearchPB.QueryResponseResultHisto $ MetricPB.HistoIntStat histo
+                SearchPB.QueryResponseResultHisto $
+                  MetricPB.HistoIntStat histo
             SearchPB.QueryRequest_QueryTypeQUERY_HISTO_REVIEWS_AND_COMMENTS -> do
               histo <- Q.runMetricTrendIntPB Q.metricReviewsAndComments
               pure . SearchPB.QueryResponse . Just $
-                SearchPB.QueryResponseResultHisto $ MetricPB.HistoIntStat histo
+                SearchPB.QueryResponseResultHisto $
+                  MetricPB.HistoIntStat histo
         Left err -> pure . handleError $ err
 
     handleError :: ParseError -> SearchPB.QueryResponse
     handleError (ParseError msg offset) =
-      SearchPB.QueryResponse . Just
+      SearchPB.QueryResponse
+        . Just
         . SearchPB.QueryResponseResultError
         $ SearchPB.QueryError
           (from msg)
@@ -623,11 +631,11 @@ searchQuery auth request = checkAuth auth response
     handleTopAuthorsQ :: Word32 -> (Word32 -> QueryM Q.TermsResultWTH) -> QueryM SearchPB.QueryResponse
     handleTopAuthorsQ limit cb = do
       results <- cb limit
-      pure $
-        SearchPB.QueryResponse
+      pure
+        $ SearchPB.QueryResponse
           . Just
-          $ SearchPB.QueryResponseResultTopAuthors $
-            toTermsCount (V.fromList $ toTTResult <$> Q.tsrTR results) (toInt $ Q.tsrTH results)
+        $ SearchPB.QueryResponseResultTopAuthors
+        $ toTermsCount (V.fromList $ toTTResult <$> Q.tsrTR results) (toInt $ Q.tsrTH results)
       where
         toInt c = fromInteger $ toInteger c
 

--- a/src/Monocle/Backend/Index.hs
+++ b/src/Monocle/Backend/Index.hs
@@ -278,7 +278,8 @@ upgradeConfigV1 = do
             setLastUpdated
               (from ecmCrawlerName)
               lastUpdatedAt
-              $ Project . from $ ecmCrawlerTypeValue
+              $ Project . from
+              $ ecmCrawlerTypeValue
 
 upgradeConfigV2 :: QueryM ()
 upgradeConfigV2 = do
@@ -485,7 +486,8 @@ bulkStream s = do
   (count :> _) <- S.sum . S.mapM callBulk . S.mapped S.toList . S.chunksOf 500 $ s
   when (count > 0) $
     -- TODO: check for refresh errors ?
-    void $ BH.refreshIndex =<< getIndexName
+    void $
+      BH.refreshIndex =<< getIndexName
   pure count
   where
     callBulk :: [BH.BulkOperation] -> QueryM Int

--- a/src/Monocle/Backend/Queries.hs
+++ b/src/Monocle/Backend/Queries.hs
@@ -369,7 +369,10 @@ instance BucketName NoSubBucket where
 instance (FromJSON a, BucketName a) => FromJSON (HistoBucket a) where
   parseJSON (Object v) = do
     HistoBucket
-      <$> v .: "key" <*> v .: "key_as_string" <*> v .: "doc_count" <*> parseSubBucket
+      <$> v .: "key"
+      <*> v .: "key_as_string"
+      <*> v .: "doc_count"
+      <*> parseSubBucket
     where
       subKeyName = bucketName (Proxy @a)
       parseSubBucket

--- a/src/Monocle/Class.hs
+++ b/src/Monocle/Class.hs
@@ -157,5 +157,6 @@ constantRetry msg handler baseAction = retry policy (const handler) action
     policy = Retry.constantDelay delay <> Retry.limitRetries retryLimit
     action num = do
       when (num > 0) $
-        mLog . Log Macroscope . LogRaw $ counterT num retryLimit <> " failed: " <> msg
+        mLog . Log Macroscope . LogRaw $
+          counterT num retryLimit <> " failed: " <> msg
       baseAction num

--- a/src/Monocle/Main.hs
+++ b/src/Monocle/Main.hs
@@ -167,9 +167,11 @@ run ApiConfig {..} = withLogger $ \glLogger -> do
   bhEnv <- mkEnv elasticUrl
   let aEnv = Env {..}
   httpRetry ("elastic-client", elasticUrl, "internal") $
-    liftIO $ traverse_ (\tenant -> runQueryM' bhEnv tenant I.ensureIndex) workspaces
+    liftIO $
+      traverse_ (\tenant -> runQueryM' bhEnv tenant I.ensureIndex) workspaces
   httpRetry ("elastic-client", elasticUrl, "internal") $
-    liftIO $ runQueryTarget bhEnv (QueryConfig conf) I.ensureConfigIndex
+    liftIO $
+      runQueryTarget bhEnv (QueryConfig conf) I.ensureConfigIndex
   liftIO $
     withStdoutLogger $ \aplogger -> do
       let settings = Warp.setPort port $ Warp.setLogger aplogger Warp.defaultSettings


### PR DESCRIPTION
This change replace the local package set with a re-usable set
defined in podenv/hspkgs.

This change also bumps ghc to 9.2.4