### PR TITLE
Update CHANGELOG about the new image name and fix commit in docker build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - [web] Keep User-Agent to the URI after an OIDC login to Monocle.
 - [nix] The project is now available as an installable flake. The file structure has been updated. Development environment is provided by `nix develop` instead of `nix-shell`.
 - [compose] Bumped Elasticsearch to 7.17.5.
+- [compose] Changed the image name from `monocle_api` to `monocle`.
 
 ### Removed
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ ARG MONOCLE_COMMIT
 
 # Build project
 COPY . /build
-RUN cabal v2-install -v1 exe:monocle
+RUN echo "Building monocle '${MONOCLE_COMMIT}'" && \
+    env MONOCLE_COMMIT=$MONOCLE_COMMIT cabal v2-install -v1 exe:monocle
 
 # web build
 FROM registry.fedoraproject.org/fedora:35


### PR DESCRIPTION
This change ensures the git version built in the CI is properly passed to
the template haskell.