### PR TITLE
Fix merged and abandoned count to use the right field

### DIFF
--- a/src/Monocle/Backend/Queries.hs
+++ b/src/Monocle/Backend/Queries.hs
@@ -1252,7 +1252,7 @@ changeEventCount mi dt =
   Metric mi (Num . countToWord <$> compute) computeTrend topNotSupported
  where
   compute = withFilter [documentType dt] (withFlavor qf countDocs)
-  computeTrend interval = withDocType EChangeCreatedEvent qf $ countHisto CreatedAt interval
+  computeTrend interval = withDocType dt qf $ countHisto CreatedAt interval
   qf = QueryFlavor OnAuthor CreatedAt
 
 changeEventFlavorDesc :: Text


### PR DESCRIPTION
In a previous metric refactor, the merged and abandoned count was
using the hardcoded EChangeCreatedEvent event type instead of the
desired `dt` type.