### PR TITLE
api - add the `file` query field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [master]
 ### Added
 
+- [api] Add the `file` field to the query language to filter changes changing at least a file path that match the regex.
+
 ### Changed
 ### Removed
 ### Fixed

--- a/src/Monocle/Search/Query.hs
+++ b/src/Monocle/Search/Query.hs
@@ -148,6 +148,7 @@ fields =
   , ("approval", (fieldText, "approval", "Change approval name"))
   , ("ttm", (fieldNumber, "duration", "Change duration (Time To Merge) in second(s)"))
   , ("tag", (fieldText, "labels", "Change tag name"))
+  , ("file", (fieldRegex, "changed_files.path", "File path"))
   , ("task.priority", (fieldText, "tasks_data.priority", "Task priority"))
   , ("task.severity", (fieldText, "tasks_data.severity", "Task severity"))
   , ("task.tag", (fieldRegex, "tasks_data.ttype", "Task tag name"))

--- a/src/Tests.hs
+++ b/src/Tests.hs
@@ -461,6 +461,12 @@ monocleSearchLanguage =
             "{\"range\":{\"duration\":{\"boost\":1,\"gt\":3600}}}"
         )
     , testCase
+        "Query file field"
+        ( queryMatch
+            "file:tests/*"
+            "{\"regexp\":{\"changed_files.path\":{\"flags\":\"ALL\",\"value\":\"tests/*\"}}}"
+        )
+    , testCase
         "Query project"
         ( queryMatch
             "project:zuul"


### PR DESCRIPTION
It allows to filter changes changing at least a file path that match the regex. Change's events match as well as they own the same field.

#resolves #950
#resolves #544