### PR TITLE
Set latest stable as default version for compose and k8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,13 @@ the configuration.
 
 ### Start docker-compose
 
-By default docker-compose will fetch the latest published container images.
-Indeed, we produce container images for the master version of Monocle.
-If running master does not fit your needs, you could still use the last release
-by setting the MONOCLE_VERSION to 1.7.0 in the .env file. Please refer
-to [System configuration section](#system).
+The docker-compose file is set to use the container image of the latest stable
+release of Monocle (1.7.0). It is adviced to use the latest stable Monocle version.
+However, as our CI publishes the latest (devel) container image then it is possible
+to run the very last version. To do so set `COMPOSE_MONOCLE_VERSION` to `latest` in
+the `.env` file.
+
+Please refer to the [Environment variables section](#environment-variables).
 
 Start Monocle:
 
@@ -128,7 +130,7 @@ propose configuration changes. The Monocle API automatically reload the configur
 
 For a local deployment, default settings are fine.
 
-The following settings are available in the `.env` file:
+The following settings are available in the `.env` file (See `.env.sample` for a sample file):
 
 - `COMPOSE_ES_XMS and COMPOSE_ES_XMX` to change the ElasticSearch JVM HEAP SIZE. By default 512m.
 - `COMPOSE_MONOCLE_VERSION` to use a specific version. By default it uses `latest`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       retries: 6
       test: "curl --silent --fail localhost:8080/health || exit 1"
       timeout: "60s"
-    image: "quay.io/change-metrics/monocle:${COMPOSE_MONOCLE_VERSION:-latest}"
+    image: "quay.io/change-metrics/monocle:${COMPOSE_MONOCLE_VERSION:-1.7.0}"
     ports:
       - "${COMPOSE_MONOCLE_API_ADDR:-0.0.0.0}:${COMPOSE_MONOCLE_API_PORT:-8080}:8080"
     restart: unless-stopped
@@ -33,7 +33,7 @@ services:
       retries: 6
       test: "curl --silent --fail localhost:9001/health || exit 1"
       timeout: "60s"
-    image: "quay.io/change-metrics/monocle:${COMPOSE_MONOCLE_VERSION:-latest}"
+    image: "quay.io/change-metrics/monocle:${COMPOSE_MONOCLE_VERSION:-1.7.0}"
     restart: unless-stopped
     volumes:
       - "./etc:/etc/monocle:z"

--- a/k8s/api-deployment.yaml
+++ b/k8s/api-deployment.yaml
@@ -29,7 +29,7 @@ spec:
           env:
             - name: MONOCLE_ELASTIC_URL
               value: http://elastic:9200
-          image: quay.io/change-metrics/monocle:latest
+          image: quay.io/change-metrics/monocle:1.7.0
           livenessProbe:
             httpGet:
               path: /health

--- a/k8s/crawler-deployment.yaml
+++ b/k8s/crawler-deployment.yaml
@@ -29,7 +29,7 @@ spec:
           env:
             - name: MONOCLE_PUBLIC_URL
               value: http://api:8080
-          image: quay.io/change-metrics/monocle:latest
+          image: quay.io/change-metrics/monocle:1.7.0
           name: crawler
           resources: {}
           livenessProbe:


### PR DESCRIPTION
Made the default to last the stable instead of the master image. This will help to avoid Monocle user to experience issues because they deployed the very last image.