### PR TITLE
crawler - Github PR - relax ratelimit in case deactivated in GHE

### DIFF
--- a/src/Lentille/GitHub/RateLimit.hs
+++ b/src/Lentille/GitHub/RateLimit.hs
@@ -25,17 +25,18 @@ defineByDocumentFile
     }
   |]
 
-transformResponse :: GetRateLimit -> RateLimit
+transformResponse :: GetRateLimit -> Maybe RateLimit
 transformResponse = \case
   GetRateLimit
     ( Just
         (RateLimitRateLimit used remaining (DateTime resetAt'))
       ) -> case parseDateValue $ from resetAt' of
-      Just resetAt -> RateLimit {..}
+      Just resetAt -> Just RateLimit {..}
       Nothing -> error $ "Unable to parse the resetAt date string: " <> resetAt'
+  GetRateLimit Nothing -> Nothing
   respOther -> error ("Invalid response: " <> show respOther)
 
-getRateLimit :: GraphEffects es => GraphClient -> Eff es RateLimit
+getRateLimit :: GraphEffects es => GraphClient -> Eff es (Maybe RateLimit)
 getRateLimit client = do
   transformResponse
     <$> doRequest client mkRateLimitArgs (Just retryCheck) Nothing Nothing

--- a/src/Lentille/GraphQL.hs
+++ b/src/Lentille/GraphQL.hs
@@ -172,7 +172,7 @@ data StreamFetchOptParams m a = StreamFetchOptParams
   -- ^ an optional exception handler
   , fpDepth :: Maybe Int
   -- ^ an optional starting value for the depth
-  , fpGetRatelimit :: Maybe (GraphClient -> m RateLimit)
+  , fpGetRatelimit :: Maybe (GraphClient -> m (Maybe RateLimit))
   -- ^ an optional action to get a RateLimit record
   }
 
@@ -224,7 +224,7 @@ streamFetch client@GraphClient {..} mkArgs StreamFetchOptParams {..} transformRe
             rl <- getRateLimit client
             -- Wait few moment to delay the next call
             mThreadDelay retryDelay
-            pure (Just rl, ())
+            pure (rl, ())
       Nothing -> pure ()
 
     -- Perform the GraphQL request


### PR DESCRIPTION
According to #958, the rate limit system can be deactivated in GHE.

This change updates the Github PR crawler to handle a ratelimit returned as null by the API. In this case Macroscope's GraphQL stream handler does not check for the internal RateLimit object because stored as Nothing then the waiting delay to honor a ratelimit is skipped.

Related to issue: #958

This commit does not handle the case for other Github crawlers. If this is accepted some follow-up patches will be needed to handle this is other Github crawlers.