### PR TITLE
Convert the author search page to use htmx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - [api] Add the `file` field to the query language to filter changes changing at least a file path that match the regex.
+- [web] Search authors page displays the total count of authors.
 
 ### Changed
 

--- a/monocle.cabal
+++ b/monocle.cabal
@@ -152,6 +152,7 @@ library
                      , jose                       >= 0.9
                      , lens
                      , lens-aeson
+                     , lucid                      >= 2.11.1
                      , megaparsec                 >= 9
                      , morpheus-graphql-client    ^>= 0.19
                      , mmorph
@@ -172,6 +173,7 @@ library
                      , servant-server             >= 0.18.2
                      , servant-auth-server        >= 0.4.1.0
                      , servant-blaze              >= 0.9.1
+                     , servant-lucid              >= 0.9.0.5
                      -- , servant-effectful (enabled after https://github.com/Kleidukos/servant-effectful/issues/5)
                      , streaming                  >= 0.2
                      , string-interpolate         >= 0.3.1.2
@@ -208,6 +210,7 @@ library
                      , Monocle.Entity
                      , Monocle.Main
                      , Monocle.Api.Server
+                     , Monocle.Api.ServerHTMX
                      , Monocle.Api.Test
                      , Monocle.Api.Jwt
 
@@ -217,8 +220,9 @@ library
 
                      -- servant
                      , Monocle.Servant.HTTP
-                     , Monocle.Servant.HTTPAuth
+                     , Monocle.Servant.HTTPMain
                      , Monocle.Servant.PBJSON
+                     , Monocle.Servant.HTMX
 
                      -- bloodhound
                      , Monocle.Backend.Documents

--- a/src/Monocle/Api/ServerHTMX.hs
+++ b/src/Monocle/Api/ServerHTMX.hs
@@ -1,0 +1,74 @@
+module Monocle.Api.ServerHTMX where
+
+import Data.String.Interpolate (iii)
+import Data.Vector qualified as V
+import Lucid
+import Lucid.Base
+import Monocle.Api.Jwt (AuthenticatedUser (AUser))
+import Monocle.Api.Server (searchAuthor)
+import Monocle.Effects (ApiEffects)
+import Monocle.Prelude
+import Monocle.Protob.Search (AuthorRequest (..))
+import Monocle.Protob.Search qualified as SearchPB
+import Servant.Auth.Server
+
+hxGet, hxTrigger, hxTarget, hxVals :: Text -> Attribute
+hxGet = makeAttribute "hx-get"
+hxTrigger = makeAttribute "hx-trigger"
+hxTarget = makeAttribute "hx-target"
+hxVals = makeAttribute "hx-vals"
+
+searchAuthorsHandler :: ApiEffects es => Maybe Text -> Maybe Text -> Eff es (Html ())
+searchAuthorsHandler Nothing _ = pure $ pure ()
+searchAuthorsHandler (Just index) queryM = do
+  case queryM of
+    Just query -> do
+      (SearchPB.AuthorResponse results) <-
+        searchAuthor
+          (Authenticated (AUser mempty "" 0))
+          (AuthorRequest (from index) (from query))
+      case toList results of
+        [] -> pure $ div_ "No Results"
+        _xs -> pure $ mapM_ authorToMarkup results
+    Nothing -> pure $ do
+      div_ [class_ "pf-c-card__body"] $ do
+        div_ [class_ "pf-l-stack pf-m-gutter"] $ do
+          div_ [class_ "pf-l-stack__item"] $ do
+            div_ [id_ "search-input"] $
+              input_
+                [ type_ "text"
+                , name_ "search"
+                , class_ "pf-c-form-control"
+                , placeholder_ "Start typing to search authors"
+                , hxGet "/htmx/authors_search"
+                , hxVals [iii|{"index": "#{index}"}|]
+                , hxTrigger "keyup changed delay:500ms, search"
+                , hxTarget "#search-results"
+                ]
+          div_ [class_ "pf-l-stack__item"] $ do
+            div_ [id_ "search-results"] ""
+          script_ pushToRouter
+ where
+  pushToRouter =
+    [iii|function pushToRouter(index, entity, name) {
+        return RescriptReactRouter.push("/" + index + "/" + entity + "/" + encodeURIComponent(name))};
+    |]
+  authorToMarkup :: SearchPB.Author -> Html ()
+  authorToMarkup (SearchPB.Author muid aliases groups) = do
+    div_ [class_ "pf-c-card pf-m-compact"] $ do
+      div_ [class_ "pf-c-card__body"] $ do
+        div_ [class_ "pf-l-flex"] $ do
+          a_ [onclick_ clickAuthorF] $ toHtml muid
+          unless (V.null aliases) aliasesH
+          unless (V.null groups) groupH
+   where
+    clickAuthorF = [iii|pushToRouter("#{index}","author","#{muid}")|]
+    clickGroupF groupName = [iii|pushToRouter("#{index}","group","#{groupName}")|]
+    aliasesH = do
+      hr_ [class_ "pf-c-divider pf-m-vertical"]
+      ul_ [class_ "pf-c-list pf-m-inline"] $ do
+        mapM_ (li_ . toHtml) aliases
+    groupH = do
+      hr_ [class_ "pf-c-divider pf-m-vertical"]
+      ul_ [class_ "pf-c-list pf-m-inline"] $ do
+        mapM_ (\g -> li_ . a_ [onclick_ $ clickGroupF g] $ toHtml g) groups

--- a/src/Monocle/Api/ServerHTMX.hs
+++ b/src/Monocle/Api/ServerHTMX.hs
@@ -4,7 +4,7 @@ import Data.String.Interpolate (iii)
 import Data.Vector qualified as V
 import Lucid
 import Lucid.Base
-import Monocle.Api.Jwt (AuthenticatedUser (AUser))
+import Monocle.Api.Jwt (AuthenticatedUser)
 import Monocle.Api.Server (searchAuthor)
 import Monocle.Effects (ApiEffects)
 import Monocle.Prelude
@@ -18,15 +18,13 @@ hxTrigger = makeAttribute "hx-trigger"
 hxTarget = makeAttribute "hx-target"
 hxVals = makeAttribute "hx-vals"
 
-searchAuthorsHandler :: ApiEffects es => Maybe Text -> Maybe Text -> Eff es (Html ())
-searchAuthorsHandler Nothing _ = pure $ pure ()
-searchAuthorsHandler (Just index) queryM = do
+searchAuthorsHandler :: ApiEffects es => AuthResult AuthenticatedUser -> Maybe Text -> Maybe Text -> Eff es (Html ())
+searchAuthorsHandler _ Nothing _ = pure $ pure ()
+searchAuthorsHandler auth (Just index) queryM = do
   case queryM of
     Just query -> do
       (SearchPB.AuthorResponse results) <-
-        searchAuthor
-          (Authenticated (AUser mempty "" 0))
-          (AuthorRequest (from index) (from query))
+        searchAuthor auth (AuthorRequest (from index) (from query))
       case toList results of
         [] -> pure $ div_ "No Results"
         _xs -> pure $ mapM_ authorToMarkup results

--- a/src/Monocle/Env.hs
+++ b/src/Monocle/Env.hs
@@ -50,14 +50,20 @@ mkEnv' = do
 mkConfig :: Text -> Config.Index
 mkConfig = Config.mkTenant
 
+indexNamePrefix :: Text
+indexNamePrefix = "monocle.changes.1."
+
 envToIndexName :: QueryTarget -> BH.IndexName
 envToIndexName target = do
   case target of
-    QueryWorkspace ws -> tenantIndexName ws
+    QueryWorkspace ws -> indexName ws
     QueryConfig _ -> BH.IndexName "monocle.config"
  where
-  tenantIndexName :: Config.Index -> BH.IndexName
-  tenantIndexName Config.Index {..} = BH.IndexName $ "monocle.changes.1." <> name
+  indexName :: Config.Index -> BH.IndexName
+  indexName Config.Index {..} = tenantIndexName name
+
+tenantIndexName :: Text -> BH.IndexName
+tenantIndexName indexName = BH.IndexName $ indexNamePrefix <> indexName
 
 -- | 'mkQuery' creates a Q.Query from a BH.Query
 mkQuery :: [BH.Query] -> Q.Query

--- a/src/Monocle/Main.hs
+++ b/src/Monocle/Main.hs
@@ -6,6 +6,7 @@ import Data.Text qualified as Text
 import Data.Text.IO qualified as Text
 import Monocle.Api.Jwt (doGenJwk, initOIDCEnv)
 import Monocle.Api.Server (handleLoggedIn, handleLogin)
+import Monocle.Api.ServerHTMX (searchAuthorsHandler)
 import Monocle.Backend.Index qualified as I
 import Monocle.Config (getAuthProvider, opName)
 import Monocle.Config qualified as Config
@@ -13,7 +14,7 @@ import Monocle.Env
 import Monocle.Prelude
 import Monocle.Search.Query (loadAliases)
 import Monocle.Servant.HTTP (server)
-import Monocle.Servant.HTTPAuth (RootAPI)
+import Monocle.Servant.HTTPMain (RootAPI)
 import Network.HTTP.Types.Status qualified as HTTP
 import Network.Wai qualified as Wai
 import Network.Wai.Handler.Warp qualified as Warp
@@ -36,7 +37,7 @@ import Monocle.Effects
 rootServer :: ApiEffects es => '[E.Concurrent] :>> es => CookieSettings -> Servant.ServerT RootAPI (Eff es)
 rootServer cookieSettings = app :<|> app
  where
-  app = server :<|> handleLogin :<|> handleLoggedIn cookieSettings
+  app = server :<|> searchAuthorsHandler :<|> handleLogin :<|> handleLoggedIn cookieSettings
 
 fallbackWebAppPath :: FilePath
 fallbackWebAppPath = "web/build/"

--- a/src/Monocle/Servant/HTMX.hs
+++ b/src/Monocle/Servant/HTMX.hs
@@ -1,0 +1,9 @@
+module Monocle.Servant.HTMX where
+
+import Data.Text
+import Lucid (Html)
+import Servant
+import Servant.HTML.Lucid (HTML)
+
+type HtmxAPI =
+  "htmx" :> "authors_search" :> QueryParam "index" Text :> QueryParam "search" Text :> Get '[HTML] (Html ())

--- a/src/Monocle/Servant/HTMX.hs
+++ b/src/Monocle/Servant/HTMX.hs
@@ -2,8 +2,15 @@ module Monocle.Servant.HTMX where
 
 import Data.Text
 import Lucid (Html)
+import Monocle.Api.Jwt (AuthenticatedUser)
 import Servant
+import Servant.Auth.Server
 import Servant.HTML.Lucid (HTML)
 
 type HtmxAPI =
-  "htmx" :> "authors_search" :> QueryParam "index" Text :> QueryParam "search" Text :> Get '[HTML] (Html ())
+  "htmx"
+    :> "authors_search"
+    :> Auth '[JWT, Cookie] AuthenticatedUser
+    :> QueryParam "index" Text
+    :> QueryParam "search" Text
+    :> Get '[HTML] (Html ())

--- a/src/Monocle/Servant/HTTPMain.hs
+++ b/src/Monocle/Servant/HTTPMain.hs
@@ -1,7 +1,8 @@
-module Monocle.Servant.HTTPAuth where
+module Monocle.Servant.HTTPMain where
 
 import Data.Text
 import Monocle.Api.Jwt (LoginInUser (..))
+import Monocle.Servant.HTMX
 import Monocle.Servant.HTTP
 import Servant
 import Servant.Auth.Server (SetCookie)
@@ -9,7 +10,7 @@ import Servant.HTML.Blaze (HTML)
 
 -- | The API is served at both `/api/2/` (for backward compat with the legacy nginx proxy)
 -- and `/` (for compat with crawler client)
-type MonocleAPI' = MonocleAPI :<|> AuthAPI
+type MonocleAPI' = MonocleAPI :<|> HtmxAPI :<|> AuthAPI
 
 type RootAPI = "api" :> "2" :> MonocleAPI' :<|> MonocleAPI'
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18,6 +18,7 @@
         "bs-parse": "git+https://github.com/aitoroses/bs-parse.git",
         "chart.js": "^2.9.4",
         "concurrently": "^6.0.2",
+        "htmx.org": "1.8.0",
         "interweave": "^12.7.1",
         "interweave-autolink": "^4.4.1",
         "jwt-decode": "^3.1.2",
@@ -1602,6 +1603,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/htmx.org": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-1.8.0.tgz",
+      "integrity": "sha512-xdR2PeSmhftFhUKn/5DYDFRVF8DagJR9d7y3AK+gQzoAQ+08r+0shaCTo1HdXKGKhRfX/uL3rqj4ZwCBNf8tLw=="
     },
     "node_modules/http-auth": {
       "version": "3.1.3",
@@ -5090,6 +5096,11 @@
           }
         }
       }
+    },
+    "htmx.org": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-1.8.0.tgz",
+      "integrity": "sha512-xdR2PeSmhftFhUKn/5DYDFRVF8DagJR9d7y3AK+gQzoAQ+08r+0shaCTo1HdXKGKhRfX/uL3rqj4ZwCBNf8tLw=="
     },
     "http-auth": {
       "version": "3.1.3",

--- a/web/package.json
+++ b/web/package.json
@@ -24,7 +24,8 @@
     "react-datepicker": "^3.7.0",
     "react-dom": "^17.0.2",
     "react-event-timeline": "^1.6.3",
-    "yargs-parser": "^20.2.7"
+    "yargs-parser": "^20.2.7",
+    "htmx.org": "1.8.0"
   },
   "scripts": {
     "start": "mkdir -p build && npm run build && npm run live",

--- a/web/src/Index.res
+++ b/web/src/Index.res
@@ -2,6 +2,7 @@
 import '@patternfly/react-core/dist/styles/base.css'
 import '@patternfly/react-styles/css/components/Table/table.css'
 import './index.css'
+import 'htmx.org';
 `)
 
 switch ReactDOM.querySelector("#root") {

--- a/web/src/Index.res
+++ b/web/src/Index.res
@@ -1,6 +1,8 @@
 %%raw(`
 import '@patternfly/react-core/dist/styles/base.css'
 import '@patternfly/react-styles/css/components/Table/table.css'
+// This global import is need for having access to the REScriptRouter from injected script (HTMX)
+globalThis.RescriptReactRouter = require("@rescript/react/src/RescriptReactRouter.bs.js");
 import './index.css'
 import 'htmx.org';
 `)

--- a/web/src/components/AuthorSearch.res
+++ b/web/src/components/AuthorSearch.res
@@ -2,7 +2,7 @@ open Prelude
 
 @react.component
 let make = (~store: Store.t) => {
-  let title = "Search an author"
+  let title = "Search authors"
   let tooltip_content = "Use this form to search authors over all event authors"
   let icon = <Patternfly.Icons.Users />
   let (state, _) = store

--- a/web/src/components/AuthorSearch.res
+++ b/web/src/components/AuthorSearch.res
@@ -1,106 +1,28 @@
 open Prelude
 
-module AuthorItem = {
-  @react.component
-  let make = (~store: Store.t, ~author: SearchTypes.author) => {
-    let (state, _) = store
-    let authorLink = "/" ++ state.index ++ "/author/" ++ author.muid->Js.Global.encodeURIComponent
-    let groupLink = group => "/" ++ state.index ++ "/group/" ++ group->Js.Global.encodeURIComponent
-    let toAliasesList = aliases =>
-      <List variant=#Inline>
-        {aliases
-        ->Belt.List.map(alias => <ListItem key={alias}> {alias} </ListItem>)
-        ->Belt.List.toArray
-        ->React.array}
-      </List>
-    let toGroupList = groups =>
-      <List variant=#Inline>
-        {groups
-        ->Belt.List.map(group =>
-          <ListItem key={group}>
-            <a onClick={_ => group->groupLink->RescriptReactRouter.push}> {group->str} </a>
-          </ListItem>
-        )
-        ->Belt.List.toArray
-        ->React.array}
-      </List>
-
-    let details = (author: SearchTypes.author) =>
-      author.aliases->Belt.List.length > 0
-        ? <>
-            <Patternfly.Divider isVertical={true} />
-            <Patternfly.Layout.FlexItem>
-              {author.aliases->toAliasesList}
-            </Patternfly.Layout.FlexItem>
-            <Patternfly.Divider isVertical={true} />
-            <Patternfly.Layout.FlexItem> {author.groups->toGroupList} </Patternfly.Layout.FlexItem>
-          </>
-        : React.null
-
-    <MSimpleCard>
-      <Patternfly.Layout.Flex>
-        <Patternfly.Layout.FlexItem>
-          <a onClick={_ => authorLink->RescriptReactRouter.push}> <b> {author.muid->str} </b> </a>
-        </Patternfly.Layout.FlexItem>
-        {author->details}
-      </Patternfly.Layout.Flex>
-    </MSimpleCard>
-  }
-}
-
 @react.component
 let make = (~store: Store.t) => {
-  let (state, _) = store
-
-  let (matchQuery, setMatchQuery) = React.useState(_ => "")
-  let (currentTimeoutId, setCurrentTimeoutId) = React.useState(_ => None)
-  let (trigger, setTrigger) = React.useState(_ => "")
-
   let title = "Search an author"
   let tooltip_content = "Use this form to search authors over all event authors"
   let icon = <Patternfly.Icons.Users />
-
-  let onChange = (input, _) => {
-    setMatchQuery(_ => input)
-    switch currentTimeoutId {
-    | Some(tid) => Js.Global.clearTimeout(tid)
-    | None => ()
-    }
-    matchQuery->Js.String2.length > 1
-      ? setCurrentTimeoutId(_ =>
-          Js.Global.setTimeout(() => setTrigger(_ => matchQuery), 1500)->Some
-        )
-      : ()
-  }
-
-  let toAuthorsResults = (resp: SearchTypes.author_response) =>
-    resp.authors->Belt.List.map(author => <AuthorItem key={author.muid} store author />)
-
-  let results =
-    <Patternfly.Layout.StackItem>
-      <NetworkRender
-        get={() =>
-          WebApi.Search.author({
-            SearchTypes.index: state.index,
-            SearchTypes.query: matchQuery,
-          })}
-        trigger
-        render={(resp: SearchTypes.author_response) => {
-          resp.authors->Belt.List.length > 0
-            ? resp->toAuthorsResults->Belt.List.toArray->React.array
-            : <Alert title={"No result found"} />
-        }}
-      />
-    </Patternfly.Layout.StackItem>
-
-  <MonoCard title tooltip_content icon>
-    <Patternfly.Layout.Stack hasGutter={true}>
-      <Patternfly.Layout.StackItem>
-        <Patternfly.TextInput id="matchQuery" _type=#Text value={matchQuery} onChange />
-      </Patternfly.Layout.StackItem>
-      {trigger->Js.String2.length > 0 ? results : React.null}
-    </Patternfly.Layout.Stack>
-  </MonoCard>
+  let (state, _) = store
+  let hxvals = Js.String2.concatMany("{\"index\": \"", [state.index, "\"}"])
+  <Card isCompact=true>
+    <CardTitle>
+      <MGrid>
+        <MGridItemXl9>
+          <Title headingLevel=#H3>
+            <Tooltip content=tooltip_content> {icon} </Tooltip> {(" " ++ title)->str}
+          </Title>
+        </MGridItemXl9>
+      </MGrid>
+    </CardTitle>
+    <CardBody>
+      <HTMXGetHook url="/api/2/htmx/authors_search" trigger="load" hxVals=hxvals>
+        <p> {"loading..."->str} </p>
+      </HTMXGetHook>
+    </CardBody>
+  </Card>
 }
 
 let default = make

--- a/web/src/components/Prelude.res
+++ b/web/src/components/Prelude.res
@@ -692,3 +692,16 @@ module MonoTabs = {
     ~onSelect: (unit, string) => unit=?,
   ) => React.element = "Tabs"
 }
+
+module HTMXGetHook = {
+  @react.component
+  let make = (~children, ~url: string, ~trigger: string) => {
+    let htmxSend = elm => {
+      React.cloneElement(elm, {"hx-get": url, "hx-trigger": trigger})
+    }
+    React.useEffect(() => {
+      %raw(`htmx.process(htmx.find("#htmx-component"))`)
+    })
+    <div id="htmx-component"> {htmxSend(children)} </div>
+  }
+}

--- a/web/src/components/Prelude.res
+++ b/web/src/components/Prelude.res
@@ -695,9 +695,12 @@ module MonoTabs = {
 
 module HTMXGetHook = {
   @react.component
-  let make = (~children, ~url: string, ~trigger: string) => {
+  let make = (~children, ~url: string, ~trigger: string, ~hxVals: string) => {
     let htmxSend = elm => {
-      React.cloneElement(elm, {"hx-get": url, "hx-trigger": trigger})
+      React.cloneElement(
+        elm,
+        {"hx-get": url, "hx-trigger": trigger, "hx-target": "closest div", "hx-vals": hxVals},
+      )
     }
     React.useEffect(() => {
       %raw(`htmx.process(htmx.find("#htmx-component"))`)


### PR DESCRIPTION
The feature is similar. Instead the active search is rendered and managed server side thanks to lucid (server side) and htmx (web ui).

- [x] Handle Auth cookie
- [x] Display the total count of authors available to the search engine