### PR TITLE
Add metricChangeReviewedAuthors and metricChangeCommentedAuthors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 
 - [crawler] Github crawler no longer crash when rate limit is deactivated on GHE (#958).
 - [api] Ordering by task's score (#833).
+- [api] Filter on "not author" for top authors metric "By changes reviewed" and "By changes commented".
 
 ## [1.7.0] - 2022-09-16
 

--- a/src/Monocle/Api/Server.hs
+++ b/src/Monocle/Api/Server.hs
@@ -591,9 +591,11 @@ searchQuery auth request = checkAuth auth response
             termsCountWord32ToResult . fromJust
               <$> Q.runMetricTop Q.metricChangeMergedAuthors queryRequestLimit
           SearchPB.QueryRequest_QueryTypeQUERY_TOP_REVIEWED_AUTHORS ->
-            handleTopAuthorsQ queryRequestLimit Q.getMostReviewedAuthor
+            termsCountWord32ToResult . fromJust
+              <$> Q.runMetricTop Q.metricChangeReviewedAuthors queryRequestLimit
           SearchPB.QueryRequest_QueryTypeQUERY_TOP_COMMENTED_AUTHORS ->
-            handleTopAuthorsQ queryRequestLimit Q.getMostCommentedAuthor
+            termsCountWord32ToResult . fromJust
+              <$> Q.runMetricTop Q.metricChangeCommentedAuthors queryRequestLimit
           SearchPB.QueryRequest_QueryTypeQUERY_TOP_AUTHORS_PEERS ->
             SearchPB.QueryResponse
               . Just
@@ -644,17 +646,6 @@ searchQuery auth request = checkAuth auth response
       . Just
       . SearchPB.QueryResponseResultTopAuthors
       . Q.toTermsCountPBInt
-
-  handleTopAuthorsQ :: Word32 -> (Word32 -> Eff es Q.TermsResultWTH) -> Eff es SearchPB.QueryResponse
-  handleTopAuthorsQ limit cb = do
-    results <- cb limit
-    pure
-      . SearchPB.QueryResponse
-      . Just
-      . SearchPB.QueryResponseResultTopAuthors
-      $ toTermsCount (V.fromList $ toTTResult <$> Q.tsrTR results) (toInt $ Q.tsrTH results)
-   where
-    toInt c = fromInteger $ toInteger c
 
   toAPeerResult :: Q.PeerStrengthResult -> SearchPB.AuthorPeer
   toAPeerResult Q.PeerStrengthResult {..} =

--- a/src/Monocle/Api/Server.hs
+++ b/src/Monocle/Api/Server.hs
@@ -847,6 +847,8 @@ metricGet auth request = checkAuth auth response
       "comment_authors" -> runMetric Q.metricCommentAuthors
       "change_authors" -> runMetric Q.metricChangeAuthors
       "change_merged_authors" -> runMetric Q.metricChangeMergedAuthors
+      "change_reviewed_authors" -> runMetric Q.metricChangeReviewedAuthors
+      "change_commented_authors" -> runMetric Q.metricChangeCommentedAuthors
       "time_to_merge" -> runMetric Q.metricTimeToMerge
       "time_to_merge_variance" -> runMetric Q.metricTimeToMergeVariance
       "first_review_mean_time" -> runMetric Q.metricFirstReviewMeanTime

--- a/src/Monocle/Backend/Queries.hs
+++ b/src/Monocle/Backend/Queries.hs
@@ -378,11 +378,7 @@ instance BucketName NoSubBucket where
 
 instance (FromJSON a, BucketName a) => FromJSON (HistoBucket a) where
   parseJSON (Object v) = do
-    HistoBucket
-      <$> v .: "key"
-      <*> v .: "key_as_string"
-      <*> v .: "doc_count"
-      <*> parseSubBucket
+    HistoBucket <$> v .: "key" <*> v .: "key_as_string" <*> v .: "doc_count" <*> parseSubBucket
    where
     subKeyName = bucketName (Proxy @a)
     parseSubBucket
@@ -512,10 +508,7 @@ data EventProjectBucketAgg = EventProjectBucketAgg
 
 instance FromJSON EventProjectBucketAgg where
   parseJSON (Object v) =
-    EventProjectBucketAgg
-      <$> v .: "key"
-      <*> v .: "doc_count"
-      <*> (unProjectBuckets <$> v .: "project")
+    EventProjectBucketAgg <$> v .: "key" <*> v .: "doc_count" <*> (unProjectBuckets <$> v .: "project")
   parseJSON _ = mzero
 
 newtype EventProjectBucketAggs = EventProjectBucketAggs {unEPBuckets :: [EventProjectBucketAgg]} deriving (Eq, Show)
@@ -1455,9 +1448,9 @@ metricReviewAuthors = Metric mi compute computeTrend computeTop
   mi =
     MetricInfo
       "review_authors"
-      "Review authors count"
-      "The count of change's review authors"
-      [iii|The metric is the count of change' reviews aggregated by unique authors. #{queryFlavorToDesc qf}|]
+      "Review' authors count"
+      "The count of change's reviewer"
+      [iii|The metric is the count of change's review authors aggregated by unique author. #{queryFlavorToDesc qf}|]
   compute =
     Num . countToWord
       <$> withFilter [documentType ev] (withFlavor qf countAuthors)
@@ -1474,9 +1467,9 @@ metricCommentAuthors = Metric mi compute computeTrend computeTop
   mi =
     MetricInfo
       "comment_authors"
-      "Comment authors count"
-      "The count of change's comment authors"
-      [iii|The metric is the count of change' comments aggregated by unique authors. #{queryFlavorToDesc qf}|]
+      "Comment' authors count"
+      "The count of change's commenter"
+      [iii|The metric is the count of change's comment authors aggregated by unique author. #{queryFlavorToDesc qf}|]
   compute =
     Num . countToWord
       <$> withFilter [documentType ev] (withFlavor qf countAuthors)

--- a/src/Monocle/Backend/Queries.hs
+++ b/src/Monocle/Backend/Queries.hs
@@ -670,16 +670,6 @@ getChangeEventsTop :: QEffects es => Word32 -> NonEmpty EDocType -> Text -> Quer
 getChangeEventsTop limit docs qfield qf =
   withFlavor qf $ getDocTypeTopCountByField docs qfield (Just limit)
 
-getMostReviewedAuthor :: QEffects es => Word32 -> Eff es TermsResultWTH
-getMostReviewedAuthor limit =
-  withFlavor (QueryFlavor Author CreatedAt) $
-    getDocTypeTopCountByField (EChangeReviewedEvent :| []) "on_author.muid" (Just limit)
-
-getMostCommentedAuthor :: QEffects es => Word32 -> Eff es TermsResultWTH
-getMostCommentedAuthor limit =
-  withFlavor (QueryFlavor Author CreatedAt) $
-    getDocTypeTopCountByField (EChangeCommentedEvent :| []) "on_author.muid" (Just limit)
-
 -- | peer strength authors
 data PeerStrengthResult = PeerStrengthResult
   { psrAuthor :: Text

--- a/src/Monocle/Backend/Test.hs
+++ b/src/Monocle/Backend/Test.hs
@@ -756,40 +756,46 @@ testTopAuthors = withTenant doTest
 
     -- Check for expected metrics
     withQuery defaultQuery do
-      results <- fromJust <$> Q.runMetricTop Q.metricChangeAuthors 10
-      assertEqual'
-        "Check metricChangeAuthors Top"
-        (V.fromList [Q.TermCount {tcTerm = "eve", tcCount = 4}])
-        (Q.tscData results)
-      results' <- fromJust <$> Q.runMetricTop Q.metricChangeMergedAuthors 10
-      assertEqual'
-        "Check metricChangeMergedAuthors Top"
-        (V.fromList [Q.TermCount {tcTerm = "eve", tcCount = 2}])
-        (Q.tscData results')
-      results'' <- fromJust <$> Q.runMetricTop Q.metricReviewAuthors 10
-      assertEqual'
-        "Check metricReviewAuthors Top"
-        ( V.fromList
-            [ Q.TermCount {tcTerm = "alice", tcCount = 2}
-            , Q.TermCount {tcTerm = "bob", tcCount = 2}
-            ]
-        )
-        (Q.tscData results'')
-      results''' <- fromJust <$> Q.runMetricTop Q.metricCommentAuthors 10
-      assertEqual'
-        "Check metricCommentAuthors Top"
-        (V.fromList [Q.TermCount {tcTerm = "alice", tcCount = 2}])
-        (Q.tscData results''')
-      results'''' <- Q.getMostReviewedAuthor 10
-      assertEqual'
-        "Check getMostReviewedAuthor count"
-        [Q.TermResult {trTerm = "eve", trCount = 4}]
-        (Q.tsrTR results'''')
-      results''''' <- Q.getMostCommentedAuthor 10
-      assertEqual'
-        "Check getMostCommentedAuthor count"
-        [Q.TermResult {trTerm = "eve", trCount = 2}]
-        (Q.tsrTR results''''')
+      do
+        results <- fromJust <$> Q.runMetricTop Q.metricChangeAuthors 10
+        assertEqual'
+          "Check metricChangeAuthors Top"
+          (V.fromList [Q.TermCount {tcTerm = "eve", tcCount = 4}])
+          (Q.tscData results)
+      do
+        results <- fromJust <$> Q.runMetricTop Q.metricChangeMergedAuthors 10
+        assertEqual'
+          "Check metricChangeMergedAuthors Top"
+          (V.fromList [Q.TermCount {tcTerm = "eve", tcCount = 2}])
+          (Q.tscData results)
+      do
+        results <- fromJust <$> Q.runMetricTop Q.metricReviewAuthors 10
+        assertEqual'
+          "Check metricReviewAuthors Top"
+          ( V.fromList
+              [ Q.TermCount {tcTerm = "alice", tcCount = 2}
+              , Q.TermCount {tcTerm = "bob", tcCount = 2}
+              ]
+          )
+          (Q.tscData results)
+      do
+        results <- fromJust <$> Q.runMetricTop Q.metricCommentAuthors 10
+        assertEqual'
+          "Check metricCommentAuthors Top"
+          (V.fromList [Q.TermCount {tcTerm = "alice", tcCount = 2}])
+          (Q.tscData results)
+      do
+        results <- fromJust <$> Q.runMetricTop Q.metricChangeReviewedAuthors 10
+        assertEqual'
+          "Check metricChangeReviewedAuthors Top"
+          (V.fromList [Q.TermCount {tcTerm = "eve", tcCount = 4}])
+          (Q.tscData results)
+      do
+        results <- fromJust <$> Q.runMetricTop Q.metricChangeCommentedAuthors 10
+        assertEqual'
+          "Check metricChangeCommentedAuthors Top"
+          (V.fromList [Q.TermCount {tcTerm = "eve", tcCount = 2}])
+          (Q.tscData results)
 
 testGetAuthorsPeersStrength :: Assertion
 testGetAuthorsPeersStrength = withTenant doTest

--- a/web/src/components/ActivePeopleView.res
+++ b/web/src/components/ActivePeopleView.res
@@ -126,13 +126,13 @@ module TopMetricsInfo = {
     | ByChangeReviewed => (
         SearchTypes.Query_top_authors_changes_reviewed,
         "By reviews",
-        tooltip_prefix ++ "reviews they performed",
+        "This shows a list of review' authors ordered by the amount of reviews they performed",
         TopTermsTable.NoLink,
       )
     | ByChangeCommented => (
         SearchTypes.Query_top_authors_changes_commented,
         "By comments",
-        tooltip_prefix ++ "comments they wrote",
+        "This shows a list of comment' authors ordered by the amount of comments they wrote",
         TopTermsTable.NoLink,
       )
     | ByMostReviewed => (


### PR DESCRIPTION
Add new standalone metrics and migrate queries QUERY_TOP_REVIEWED_AUTHORS and QUERY_TOP_COMMENTED_AUTHORS to use them.

This should also fix the issue raised here [1] where discarding an author via the query was not taken in account.

[1] https://github.com/change-metrics/monocle/issues/973#issuecomment-1287215671