### PR TITLE
Fix unsupported Authorization header pattern for Gitlab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - [crawler] Github crawler no longer crash when rate limit is deactivated on GHE (#958).
 - [api] Ordering by task's score (#833).
 - [api] Filter on "not author" for top authors metric "By changes reviewed" and "By changes commented".
+- [crawler] Support for crawling private repositories on Gitlab (#985).
 
 ## [1.7.0] - 2022-09-16
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,8 @@ the listed repositories.
 `gitlab_token` might be specified to use an alternate environment variable name to look for the
 token value. Default is "GITLAB_TOKEN"
 
+To crawl privates repositories, you must generate a Personal Access Token with the "read_api" scope.
+
 ###### TaskData
 
 Monocle provides additional crawlers to attach tasks/issues/RFEs to changes based on a

--- a/src/Lentille/GraphQL.hs
+++ b/src/Lentille/GraphQL.hs
@@ -94,7 +94,7 @@ doGraphRequest GraphClient {..} jsonBody = do
         initRequest
           { HTTP.method = "POST"
           , HTTP.requestHeaders =
-              [ ("Authorization", "token " <> encodeUtf8 (unSecret token))
+              [ ("Authorization", "Bearer " <> encodeUtf8 (unSecret token))
               , ("User-Agent", "change-metrics/monocle")
               , ("Content-Type", "application/json")
               ]


### PR DESCRIPTION
This fix makes use of the "Bearer" pattern which is supported by both Github and Gitlab.

Related-to: #985