### PR TITLE
[web] esbuild avoid identifier minification as it break htmx integration

### DIFF
--- a/web/build.js
+++ b/web/build.js
@@ -16,7 +16,12 @@ const esbuildOptions = {
   outfile: './build/dist/bundle.js',
   bundle: true,
   sourcemap: true,
-  minify: isProd,
+  // We select per option minification options
+  // minify: false,
+  minifyWhitespace: true,
+  minifySyntax: true,
+  // For some reason when set to true this option break the htmx integration
+  // minifyIdentifiers: true,
   watch: process.argv.slice(2)[0] == 'watch',
   target: ['firefox87'],
   define: {


### PR DESCRIPTION
For some reason the htmx integration for the search page is broken by the minification option.

Simply disable it, however it add a cost in term of JS bundle size.