### PR TITLE
[npm] override deps constraint react-event-timeline

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -27,6 +27,11 @@
     "yargs-parser": "^20.2.7",
     "htmx.org": "1.8.0"
   },
+  "overrides": {
+    "react-event-timeline": {
+      "react": ">= 0.14.0 < 17.1.0-0"
+    }
+  },
   "scripts": {
     "start": "mkdir -p build && npm run build && npm run live",
     "live": "concurrently --names www,res,esb -c green.bold,red.bold,blue.bold npm:dev-server npm:re:watch npm:es:watch",


### PR DESCRIPTION
The npm version provided via Fedora 35 (used to build the web UI) changed recently that raised a deps issue in our JS dependency libs.

This commit uses an override to mitigate the issue.