### PR TITLE
[auth] Add some logs when the OIDCProvider is misconfigured

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,10 +450,11 @@ Monocle supports user authentication via an OIDC (OpenID Connect) provider.
 Once authenticated, Monocle is able to display personalized content like resolving the
 *self* query value such as in the query: *author: self*.
 
-Monocle only support one provider at a time.
+Monocle supports one provider at a time.
 
-Note that by default and if no authentication system is configured, Monocle provides an
-*unauthentcated login* mechanism which allows a user to enter its *author name*.
+Note that by default and if authentication system is not configured or misconfigured,
+Monocle provides an *unauthentcated login* mechanism which allows a user to enter its
+*author name*.
 
 ##### OIDC Provider
 

--- a/src/Monocle/Main.hs
+++ b/src/Monocle/Main.hs
@@ -146,10 +146,13 @@ run' ApiConfig {..} aplogger = E.runConcurrent $ runLoggerEffect do
   let localJWTSettings = defaultJWTSettings localJwk
   -- Initialize env to talk with OIDC provider
   oidcEnv <- case providerM of
-    Just provider -> do
+    Left msg -> do
+      logWarn "AuthSystemFailed" ["invalid config" .= msg]
+      pure Nothing
+    Right (Just provider) -> do
       logInfo "AuthSystemReady" ["provider" .= opName provider]
       pure <$> liftIO (initOIDCEnv provider)
-    _ -> pure Nothing
+    Right Nothing -> pure Nothing
   let aOIDC = OIDC {..}
 
   bhEnv <- mkEnv elasticUrl


### PR DESCRIPTION
A warning log is displayed when:

- The expected envrionment varible that contain the OIDC secret is missing or empty.
- At least of mandatory OIDC setting is empty.