### PR TITLE
Update to latest morpheus-graphql-client-0.27

### DIFF
--- a/doc/tutorial/graphql-query.md
+++ b/doc/tutorial/graphql-query.md
@@ -46,9 +46,9 @@ Add to the file your query like so:
 
 ```haskell
 import Lentille.GitHub (schemaLocation)
-defineByDocumentFile
+declareLocalTypesInline
   schemaLocation
-  [gql|
+  [raw|
     { query content here }
   |]
 ```
@@ -115,9 +115,9 @@ src/Lentille/GitHub/Issues.hs:(20,8)-(45,4): Splicing expression
 As you can see, there are unknown type constructor like URI or DateTime. So add newtype for those:
 
 ```haskell
-newtype DateTime = DateTime Text deriving (Show, Eq, EncodeScalar, DecodeScalar)
+newtype DateTime = DateTime Text deriving (Show, Eq, FromJSON)
 
-newtype URI = URI Text deriving (Show, Eq, EncodeScalar, DecodeScalar)
+newtype URI = URI Text deriving (Show, Eq, FromJSON)
 ```
 
 ... then reload:

--- a/monocle.cabal
+++ b/monocle.cabal
@@ -154,7 +154,7 @@ library
                      , lens-aeson
                      , lucid                      >= 2.11.1
                      , megaparsec                 >= 9
-                     , morpheus-graphql-client    ^>= 0.19
+                     , morpheus-graphql-client    >= 0.27
                      , mmorph
                      , mtl
                      , network                    >= 3
@@ -244,6 +244,7 @@ library
                      , Lentille.GraphQL
                      , Lentille.Bugzilla
 
+                     , Lentille.GitHub.Types
                      , Lentille.GitHub.Issues
                      , Lentille.GitHub.RateLimit
                      , Lentille.GitHub.Organization

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -7,17 +7,6 @@ let
   else
     throw "Refusing to build from a dirty Git tree!";
 
-  mk-morpheus-lib = hpPrev: name:
-    let
-      morpheus-graphql-src = pkgs.fetchFromGitHub {
-        owner = "morpheusgraphql";
-        repo = "morpheus-graphql";
-        rev = "df3a4b0d11b53de3ddf3b43966e0242877541e50";
-        sha256 = "sha256-rrDWIYmY9J9iPI/lSuflyyxapAXyuHbLP86awH33mzo=";
-      };
-    in (hpPrev.callCabal2nix "morpheus-graphql-${name}"
-      "${morpheus-graphql-src}/morpheus-graphql-${name}" { });
-
   # Add monocle and patch broken dependency to the haskell package set
   haskellExtend = hpFinal: hpPrev: {
     monocle = hpPrev.callCabal2nix "monocle" self { };
@@ -42,12 +31,6 @@ let
       version = "0.19.1.0";
       sha256 = "sha256-QEN1wOLLUEsDKAbgz8ex0wfK/duNytvRYclwkBj/1G0=";
     };
-
-    # upgrade to latest morpheus needs some work
-    morpheus-graphql-tests = mk-morpheus-lib hpPrev "tests";
-    morpheus-graphql-core = mk-morpheus-lib hpPrev "core";
-    morpheus-graphql-code-gen = mk-morpheus-lib hpPrev "code-gen";
-    morpheus-graphql-client = mk-morpheus-lib hpPrev "client";
   };
 
   # create the main package set without options

--- a/src/Lentille/GitHub/RateLimit.hs
+++ b/src/Lentille/GitHub/RateLimit.hs
@@ -6,6 +6,7 @@ module Lentille.GitHub.RateLimit where
 
 import Data.Morpheus.Client
 import Lentille
+import Lentille.GitHub.Types
 import Lentille.GraphQL
 import Monocle.Prelude
 import Network.HTTP.Client (responseBody, responseStatus)
@@ -13,11 +14,9 @@ import Network.HTTP.Types (Status, badGateway502, forbidden403, ok200)
 
 import Effectful.Retry
 
-newtype DateTime = DateTime Text deriving (Show, Eq, EncodeScalar, DecodeScalar)
-
-defineByDocumentFile
+declareLocalTypesInline
   ghSchemaLocation
-  [gql|
+  [raw|
     query GetRateLimit  {
       rateLimit {
         used
@@ -31,7 +30,7 @@ transformResponse :: GetRateLimit -> Maybe RateLimit
 transformResponse = \case
   GetRateLimit
     ( Just
-        (RateLimitRateLimit used remaining (DateTime resetAt'))
+        (GetRateLimitRateLimit used remaining (DateTime resetAt'))
       ) -> case parseDateValue $ from resetAt' of
       Just resetAt -> Just RateLimit {..}
       Nothing -> error $ "Unable to parse the resetAt date string: " <> resetAt'

--- a/src/Lentille/GitHub/Types.hs
+++ b/src/Lentille/GitHub/Types.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | The API global types
+module Lentille.GitHub.Types where
+
+import Data.Morpheus.Client (declareGlobalTypesByName)
+import Lentille.GraphQL (ghSchemaLocation)
+import Monocle.Prelude
+
+newtype DateTime = DateTime Text deriving (Show, Eq, FromJSON)
+
+newtype URI = URI {unURI :: Text} deriving (Show, Eq, FromJSON)
+
+newtype GitObjectID = GitObjectID Text deriving (Show, Eq, FromJSON)
+
+declareGlobalTypesByName
+  ghSchemaLocation
+  [ "MergeableState"
+  , "PullRequestReviewDecision"
+  , "PullRequestState"
+  , "PullRequestReviewState"
+  ]

--- a/src/Lentille/GitLab/Adapter.hs
+++ b/src/Lentille/GitLab/Adapter.hs
@@ -17,7 +17,7 @@ import Monocle.Protob.Change
 import Proto3.Suite (Enumerated (..))
 import Relude
 
-newtype Time = Time Text deriving (Show, Eq, EncodeScalar, DecodeScalar)
+newtype Time = Time Text deriving (Show, Eq, FromJSON)
 
 data DiffStatsSummary = DiffStatsSummary
   { additions :: Int

--- a/src/Lentille/GitLab/Group.hs
+++ b/src/Lentille/GitLab/Group.hs
@@ -18,9 +18,9 @@ import Monocle.Protob.Crawler (Project (..))
 import Streaming.Prelude qualified as S
 
 -- https://docs.gitlab.com/ee/api/graphql/reference/#querygroup
-defineByDocumentFile
+declareLocalTypesInline
   glSchemaLocation
-  [gql|
+  [raw|
     query GetGroupProjects ($fullPath: ID!, $cursor: String) {
       group(fullPath: $fullPath) {
         projects (first: 100, after: $cursor, includeSubgroups: true) {
@@ -48,9 +48,9 @@ transformResponse result =
   case result of
     GetGroupProjects
       ( Just
-          ( GroupGroup
-              ( GroupProjectsProjectConnection
-                  (GroupProjectsPageInfoPageInfo hasNextPage endCursor)
+          ( GetGroupProjectsGroup
+              ( GetGroupProjectsGroupProjects
+                  (GetGroupProjectsGroupProjectsPageInfo hasNextPage endCursor)
                   nodes
                 )
             )
@@ -67,4 +67,4 @@ transformResponse result =
       , []
       )
  where
-  getFullPath GroupProjectsNodesProject {..} = Project . from $ unpackID fullPath
+  getFullPath GetGroupProjectsGroupProjectsNodes {..} = Project . from $ unpackID fullPath


### PR DESCRIPTION
This changes adapts the graphql client to work with the new generated code. Beside the simple new naming convention, the two other differences are:

- Removed variant partial field selector:

Before:

```haskell
data TimelineEvents =
    PullRequestReview { author :: Text, status :: Status }
  | PullRequestComment { author :: Text, comment :: Text } 
```

After:

```haskell
data PullRequestReview = PullRequestReview { author :: Text, status :: Status }
data PullRequestComment = PullRequestComment { author :: Text, comment :: Text }

data TimelineEvents =
    TimelineEventsVariantPullRequestReview PullRequestReview
  | TimelineEventsVariantPullRequestComment PullRequestComment
```

- Global types for PullRequest status needs to be generated manually, in the `Lentille.GitHub.Types` module.

Overall, this change was pretty much mechanical, though it seems like there is now room for improvement by leveraging the OverloadedRecordDot extension and by using the new global type featured in morpheus.

References:
- https://github.com/morpheusgraphql/morpheus-graphql/pull/727
- https://github.com/morpheusgraphql/morpheus-graphql/pull/773