### PR TITLE
Re-organize the CONTRIBUTING doc

### DIFF
--- a/cabal-override.project
+++ b/cabal-override.project
@@ -1,0 +1,10 @@
+package proto3-suite
+  flags: -swagger
+
+packages: .
+
+-- Enable bytestring-11
+source-repository-package
+  type: git
+  location: https://github.com/klangner/text-time
+  tag: 1ff65c2c8845e3fdd99900054f0596818a95c316

--- a/monocle.cabal
+++ b/monocle.cabal
@@ -7,11 +7,11 @@ license:             AGPL-3.0-only
 license-file:        LICENSE
 author:              Monocle authors
 maintainer:          Monocle authors <fboucher@redhat.com>
-copyright:           2021,2022 Monocle authors
+copyright:           2021,2022,2023 Monocle authors
 category:            Development
 build-type:          Simple
 extra-doc-files:     README.md
-tested-with:         GHC == 9.2.4
+tested-with:         GHC == 9.2.5
 extra-source-files:  schemas/monocle/config/**/*.dhall,
                      schemas/github/schema.docs.graphql,
                      schemas/gitlab/schema.graphql,


### PR DESCRIPTION
This commits re-organize the contributing documentation by trying to make it easier to understand and follow.

Mainly it remove the cabal way to keep only the nix way. The cabal build is not longer tested in the CI and known to be broken.