### PR TITLE
Rename unSecret into unsafeShowSecret to cleanup leak in the logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ All notable changes to this project will be documented in this file.
 ### Removed
 ### Fixed
 
+- [crawler] Authentification token are no longer written in the service logs.
+
 ## [1.8.0] - 2022-11-28
 ### Added
 
 - [api] Add the `file` field to the query language to filter changes changing at least a file path that match the regex.
 - [web] Search authors page displays the total count of authors.
-- [api] Enable the 'draft' status for Gerrit changes. 
+- [api] Enable the 'draft' status for Gerrit changes.
 - [api] Enable the "draft" state's value in the query language.
 - [web] Add the pin change button to highlight a change.
 - [web] Add the mask change button to permanently hide a change.

--- a/monocle.cabal
+++ b/monocle.cabal
@@ -143,6 +143,7 @@ library
                      , foldl
                      , gerrit                     >= 0.1.6
                      , gitrev                     >= 1.3.1
+                     , hashable
                      , hashtables                 >= 1.2
                      , http-client                >= 0.6
                      , http-client-openssl        >= 0.3

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -225,13 +225,13 @@ usageLentille =
   getGerritEnv url = do
     client <- G.getGerritClient url Nothing
     pure $ G.GerritEnv client Nothing (const Nothing) "cli"
-  getGraphClient url secret = newGraphClient url (Secret secret)
+  getGraphClient url secret = newGraphClient url (from secret)
 
   urlOption = strOption (long "url" <> O.help "API url, e.g. https://api.github.com/graphql" <> metavar "URL")
   queryOption = strOption (long "query" <> O.help "Gerrit regexp query")
   orgOption = strOption (long "organization" <> O.help "GitHub organization name")
   userOption = strOption (long "user" <> O.help "GitHub user name")
-  secretOption = strOption (long "token" <> O.help "GitHub token, get one from https://github.com/settings/tokens")
+  secretOption = into @Secret @Text <$> strOption (long "token" <> O.help "GitHub token, get one from https://github.com/settings/tokens")
   changeOption = option auto (long "change" <> O.help "Change Number" <> metavar "NR")
   projectOption = strOption (long "project" <> O.help "Project name")
   sinceOption = strOption (long "since" <> O.help "Since date")

--- a/src/Lentille/Bugzilla.hs
+++ b/src/Lentille/Bugzilla.hs
@@ -121,8 +121,8 @@ instance FromJSON BugsWithScore where
     pure $ BugsWithScore bugs
   parseJSON _ = mzero
 
-getApikey :: Text -> BZ.BugzillaApiKey
-getApikey = BZ.BugzillaApiKey
+getApikey :: Secret -> BZ.BugzillaApiKey
+getApikey = BZ.BugzillaApiKey . unsafeShowSecret
 
 -- getBugs unwraps the 'BugsWithScore' newtype wrapper
 getBugs :: BZEffects es => BZ.Request -> Eff es [BugWithScore]

--- a/src/Lentille/GraphQL.hs
+++ b/src/Lentille/GraphQL.hs
@@ -94,7 +94,7 @@ doGraphRequest GraphClient {..} jsonBody = do
         initRequest
           { HTTP.method = "POST"
           , HTTP.requestHeaders =
-              [ ("Authorization", "Bearer " <> encodeUtf8 (unSecret token))
+              [ bearerTokenHeader token
               , ("User-Agent", "change-metrics/monocle")
               , ("Content-Type", "application/json")
               ]

--- a/src/Macroscope/Main.hs
+++ b/src/Macroscope/Main.hs
@@ -18,6 +18,7 @@ module Macroscope.Main (
   mkStreamsActions,
 ) where
 
+import Data.Hashable (hash)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map qualified as Map
 import Data.Text qualified as T
@@ -249,7 +250,7 @@ getClientBZ url token = do
     mapMutate clients (url, token) . pure $
       getBugzillaSession url $
         Just $
-          getApikey (unSecret token)
+          getApikey token
   modify $ \s -> s {clientsBugzilla = newClients}
   pure (url, client)
 
@@ -259,7 +260,7 @@ getClientGraphQL url token = do
   clients <- gets clientsGraph
   (client, newClients) <- mapMutate clients (url, token) $ lift $ newGraphClient url token
   modify $ \s -> s {clientsGraph = newClients}
-  let groupKey = url <> "-" <> unSecret token
+  let groupKey = url <> "-" <> show (hash token)
   pure (groupKey, client)
 
 -- | Groups the streams by client

--- a/src/Macroscope/Test.hs
+++ b/src/Macroscope/Test.hs
@@ -157,7 +157,7 @@ testGetStream = do
     (streams, clients) <- runStateT (traverse Macroscope.getCrawler (Macroscope.getCrawlers conf)) (Macroscope.Clients mempty mempty mempty)
     assertEqual' "Two streams created" 3 (length streams)
     assertEqual' "Only two gitlab clients created" 2 (length $ toList $ Macroscope.clientsGraph clients)
-    let expected = ["http://localhost-42 for crawler-for-org1, crawler-for-org2", "http://localhost-43 for crawler-for-org3"]
+    let expected = ["http://localhost-2443212458582611272 for crawler-for-org3", "http://localhost-2443213558094239483 for crawler-for-org1, crawler-for-org2"]
     assertEqual' "Stream group named" expected (map fst $ Macroscope.mkStreamsActions (catMaybes streams))
  where
   conf =

--- a/src/Monocle/Config.hs
+++ b/src/Monocle/Config.hs
@@ -291,7 +291,7 @@ getSecret ::
   Maybe Text ->
   Eff es Secret
 getSecret def keyM =
-  Secret . decodeUtf8 . fromMaybe (error $ "Missing environment: " <> env)
+  from . fromMaybe (error $ "Missing environment: " <> env)
     <$> envGet (unTagged $ into @(UTF_8 ByteString) env)
  where
   env = fromMaybe def keyM


### PR DESCRIPTION
This change uses the Hashable instance to group network client.

Fixes #1013 