### PR TITLE
Remove prometheus and grafana from default shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,8 @@
 
   nixConfig = {
     extra-substituters = "https://change-metrics.cachix.org";
-    extra-trusted-public-keys = "change-metrics.cachix.org-1:dCe8jx9vptiF6DCdZ5y2QouvDsxgFRZnbHowhPnS4C0=";
+    extra-trusted-public-keys =
+      "change-metrics.cachix.org-1:dCe8jx9vptiF6DCdZ5y2QouvDsxgFRZnbHowhPnS4C0=";
   };
 
   inputs = {
@@ -25,7 +26,7 @@
       "github:NixOS/nixpkgs/ed014c27f4d0ca772fb57d3b8985b772b0503bbd";
     hspkgs.url =
       "github:podenv/hspkgs/4a25962c7beede6cfcacc66000ef783e5c98e483";
-      # "path:/srv/github.com/podenv/hspkgs";
+    # "path:/srv/github.com/podenv/hspkgs";
   };
 
   outputs = { self, nixpkgs, hspkgs }:
@@ -38,6 +39,7 @@
     in {
       devShell."x86_64-linux" = legacy.shell;
       devShells."x86_64-linux".ci = legacy.ci-shell;
+      devShells."x86_64-linux".monitoring = legacy.monitoring-shell;
       packages."x86_64-linux".default = legacy.monocle-exe;
       packages."x86_64-linux".env = legacy.monocle-light.env;
       packages."x86_64-linux".containerMonocle = legacy.containerMonocle;

--- a/flake.nix
+++ b/flake.nix
@@ -43,11 +43,17 @@
       packages."x86_64-linux".default = legacy.monocle-exe;
       packages."x86_64-linux".env = legacy.monocle-light.env;
       packages."x86_64-linux".containerMonocle = legacy.containerMonocle;
-      packages."x86_64-linux".containerGrafana = legacy.containerGrafana;
-      packages."x86_64-linux".containerPrometheus = legacy.containerPrometheus;
       apps."x86_64-linux".default = {
         type = "app";
         program = "${legacy.monocle-exe}/bin/monocle";
+      };
+      apps."x86_64-linux".prometheus = {
+        type = "app";
+        program = "${legacy.promStart}/bin/prometheus-start";
+      };
+      apps."x86_64-linux".grafana = {
+        type = "app";
+        program = "${legacy.grafanaStart}/bin/grafana-start";
       };
     };
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -135,7 +135,7 @@ in rec {
                 - CRAWLER_TARGET
     '';
   };
-  prom-home = "/var/lib/prometheus";
+  prom-home = "~/.local/share/monocle/prometheus-home";
   promStart = pkgs.writeScriptBin "prometheus-start" ''
     ${headers}
 
@@ -165,7 +165,7 @@ in rec {
     };
   };
 
-  grafana-home = "/var/lib/grafana";
+  grafana-home = "~/.local/share/monocle/grafana-home";
   grafanaPromDS = pkgs.writeTextFile {
     name = "prometheus.yml";
     text = ''
@@ -304,11 +304,6 @@ in rec {
 
   services-req =
     [ elasticsearchStart monocleReplStart monocleWebStart monocleGhcid ];
-
-  monitoring-shell = hsPkgs.shellFor {
-    packages = p: [ p.monocle ];
-    buildInputs = [ promStart grafanaStart ];
-  };
 
   # define the base requirements
   base-req = [ pkgs.bashInteractive hspkgs.coreutils pkgs.gnumake ];

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -302,14 +302,13 @@ in rec {
     exec ${pkgs.nodejs}/bin/npm start
   '';
 
-  services-req = [
-    elasticsearchStart
-    promStart
-    grafanaStart
-    monocleReplStart
-    monocleWebStart
-    monocleGhcid
-  ];
+  services-req =
+    [ elasticsearchStart monocleReplStart monocleWebStart monocleGhcid ];
+
+  monitoring-shell = hsPkgs.shellFor {
+    packages = p: [ p.monocle ];
+    buildInputs = [ promStart grafanaStart ];
+  };
 
   # define the base requirements
   base-req = [ pkgs.bashInteractive hspkgs.coreutils pkgs.gnumake ];


### PR DESCRIPTION
Provide a monitoring shell: nix develop .#monitoriing

This saves disk space when entering a monocle dev shell. Those tools are extra for the specific monitoring use case.