### PR TITLE
nix: export the haskellExtend overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
         self = self;
       };
     in {
+      haskellExtend = legacy.hExtend;
       devShell."x86_64-linux" = legacy.shell;
       devShells."x86_64-linux".ci = legacy.ci-shell;
       devShells."x86_64-linux".monitoring = legacy.monitoring-shell;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -74,6 +74,9 @@ let
   '';
 
 in rec {
+  # Overlay
+  hExtend = haskellExtend;
+
   # DB
   info = pkgs.lib.splitString "-" pkgs.stdenv.hostPlatform.system;
   arch = pkgs.lib.elemAt info 0;


### PR DESCRIPTION
This change enables integrating the monocle package into an external set.