### PR TITLE
Update peer strength metric computation to enable filtering by change author

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- [metric] Changed the Peer strength metric computation to enable filtering by change author (#1037).
+
 ### Removed
 
 ### Fixed

--- a/src/Monocle/Api/Server.hs
+++ b/src/Monocle/Api/Server.hs
@@ -68,6 +68,7 @@ import Effectful.Error.Static qualified as E
 import Effectful.Reader.Static (asks)
 import Monocle.Effects
 
+import Monocle.Backend.Queries (PeersStrengthMode (PSModeFilterOnAuthor))
 import Servant.API (Headers)
 import Servant.API.Header (Header)
 import Servant.Auth.Server.Internal.JWT (makeJWT)
@@ -612,7 +613,7 @@ searchQuery auth request = checkAuth auth response
               . SearchPB.AuthorsPeers
               . V.fromList
               . map toAPeerResult
-              <$> Q.getAuthorsPeersStrength queryRequestLimit
+              <$> Q.getAuthorsPeersStrength PSModeFilterOnAuthor queryRequestLimit
           SearchPB.QueryRequest_QueryTypeQUERY_NEW_CHANGES_AUTHORS -> do
             results <- take (fromInteger . toInteger $ queryRequestLimit) <$> Q.getNewContributors
             pure $

--- a/src/Monocle/Backend/Test.hs
+++ b/src/Monocle/Backend/Test.hs
@@ -31,6 +31,7 @@ import Streaming.Prelude qualified as Streaming
 import Test.Tasty.HUnit ((@?=))
 
 import Effectful.Fail qualified as E
+import Monocle.Backend.Queries (PeersStrengthMode (PSModeFilterOnAuthor, PSModeFilterOnPeer))
 import Monocle.Effects
 
 fakeDate, fakeDateAlt :: UTCTime
@@ -824,7 +825,7 @@ testGetAuthorsPeersStrength = withTenant doTest
 
     -- Check for expected metrics
     withQuery defaultQuery do
-      results <- Q.getAuthorsPeersStrength 10
+      results <- Q.getAuthorsPeersStrength PSModeFilterOnAuthor 10
       assertEqual'
         "Check getAuthorsPeersStrength results"
         [ Q.PeerStrengthResult
@@ -835,6 +836,24 @@ testGetAuthorsPeersStrength = withTenant doTest
         , Q.PeerStrengthResult
             { psrAuthor = "bob"
             , psrPeer = "alice"
+            , psrStrength = 2
+            }
+        ]
+        results
+
+    -- Check for expected metrics
+    withQuery defaultQuery do
+      results <- Q.getAuthorsPeersStrength PSModeFilterOnPeer 10
+      assertEqual'
+        "Check getAuthorsPeersStrength results"
+        [ Q.PeerStrengthResult
+            { psrAuthor = "bob"
+            , psrPeer = "eve"
+            , psrStrength = 4
+            }
+        , Q.PeerStrengthResult
+            { psrAuthor = "alice"
+            , psrPeer = "bob"
             , psrStrength = 2
             }
         ]

--- a/src/Monocle/Effects.hs
+++ b/src/Monocle/Effects.hs
@@ -366,6 +366,7 @@ runElasticEffect bhEnv action = do
 esSearch :: (ElasticEffect :> es, ToJSON body, FromJSONField resp) => BH.IndexName -> body -> BHR.ScrollRequest -> Eff es (BH.SearchResult resp)
 esSearch iname body scrollReq = do
   ElasticEffect env <- getStaticRep
+  -- unsafeEff_ $ BH.runBH env $ BHR.search iname (trace (show $ encode body) body) scrollReq
   unsafeEff_ $ BH.runBH env $ BHR.search iname body scrollReq
 
 esAdvance :: (ElasticEffect :> es, FromJSON resp) => BH.ScrollId -> Eff es (BH.SearchResult resp)

--- a/src/Monocle/Search/Query.hs
+++ b/src/Monocle/Search/Query.hs
@@ -16,6 +16,7 @@ module Monocle.Search.Query (
   rangeField,
   defaultQueryFlavor,
   dropDate,
+  dropAuthor,
   dropField,
   blankQuery,
   yearAgo,
@@ -562,3 +563,6 @@ dropField dropFieldPred (Just expr) = go expr
 
 dropDate :: Maybe Expr -> Maybe Expr
 dropDate = dropField (`elem` ["from", "to", "updated_at", "created_at"])
+
+dropAuthor :: Maybe Expr -> Maybe Expr
+dropAuthor = dropField (`elem` ["author"])

--- a/src/Tests.hs
+++ b/src/Tests.hs
@@ -514,6 +514,7 @@ monocleSearchLanguage =
     , testCase "QueryM combinator" testSimpleQueryM
     , testCase "QueryM ensureMinBound" testEnsureMinBound
     , testCase "QueryM dropDate" testDropDate
+    , testCase "QueryM dropAuthor" testDropAuthor
     ]
  where
   mkQueryM code action = runEff $ runMonoQueryConfig (mkCodeQuery code) action
@@ -557,6 +558,15 @@ monocleSearchLanguage =
     let expected = "{\"bool\":{\"must\":[{\"range\":{\"created_at\":{\"boost\":1,\"gt\":\"2020-01-01T00:00:00Z\"}}},{\"regexp\":{\"repository_fullname\":{\"flags\":\"ALL\",\"value\":\"zuul\"}}}]}}"
     liftIO $ assertEqual "match" (Just expected) got
     withModified Q.dropDate do
+      newQ <- prettyQuery
+      liftIO $ assertEqual "drop date worked" (Just "{\"regexp\":{\"repository_fullname\":{\"flags\":\"ALL\",\"value\":\"zuul\"}}}") newQ
+
+  testDropAuthor :: Assertion
+  testDropAuthor = mkQueryM "repo:zuul author:john" do
+    got <- prettyQuery
+    let expected = "{\"bool\":{\"must\":[{\"regexp\":{\"repository_fullname\":{\"flags\":\"ALL\",\"value\":\"zuul\"}}},{\"regexp\":{\"author.muid\":{\"flags\":\"ALL\",\"value\":\"john\"}}}]}}"
+    liftIO $ assertEqual "match" (Just expected) got
+    withModified Q.dropAuthor do
       newQ <- prettyQuery
       liftIO $ assertEqual "drop date worked" (Just "{\"regexp\":{\"repository_fullname\":{\"flags\":\"ALL\",\"value\":\"zuul\"}}}") newQ
 

--- a/web/src/components/PeersStrengthView.res
+++ b/web/src/components/PeersStrengthView.res
@@ -42,18 +42,18 @@ module ConnectionDiagram = {
 module PeersStrengthTable = {
   @react.component
   let make = (~items: list<SearchTypes.author_peer>) => {
-    let columnNames = ["Peer reviewer", "Change author", "Strength"]
+    let columnNames = ["Change author", "Peer reviewer", "Strength"]
 
     let isOrdered = (first: SearchTypes.author_peer, second: SearchTypes.author_peer, index) =>
       switch index {
-      | 0 => first.peer < second.peer
-      | 1 => first.author < second.author
+      | 0 => first.author < second.author
+      | 1 => first.peer < second.peer
       | 2 => first.strength < second.strength
       | _ => false
       }
     let formatters: list<SearchTypes.author_peer => React.element> = list{
-      item => item.peer->str,
       item => item.author->str,
+      item => item.peer->str,
       item => item.strength->int32_str->str,
     }
 


### PR DESCRIPTION
Update peer strength metric computation to enable filtering by change author

Fixes: #1037

This change updates the computation where now we:

Find (and filter on) changes authors and for each of them find all event authors that did a comment/review on the change author.

The previous computation was that:

Find (and filter on) comments/reviews events authors and for each of them find all changes authors on which the event's author did a comment/review.

This change also:
- Updates the web UI for the peer strength to set the author colunm on the left.
- Keeps the previous computation code but unused for now. If the previous computation is relevant we could add a switch in the UI.