### PR TITLE
add troubleshooting entry for network error message on web ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,7 @@ in your docker-compose configuration file. You can find [additional information]
 
 To disable TLS verification, set the `TLS_NO_VERIFY` environment variable to `1`.
 
+If you're accessing the web service remotely, make sure to set `MONOCLE_PUBLIC_URL` to the right URL in your `.env` file as this will be used to redirect requests from the UI. If not you'll see the UI fail with a "Network error" message.
 
 ## Wipe crawler data from the database
 


### PR DESCRIPTION
Was faced with the following error when trying to setup monocle on a remote host:
![image](https://github.com/change-metrics/monocle/assets/77528485/146d5676-77a6-4832-ab8a-0f1d80f4eadc)


Ends-up I needed to set `MONOCLE_PUBLIC_URL` to my host name to make the queries succeed, but the error was a bit confusing, so I'm at least suggesting a troubleshooting entry for this.