### PR TITLE
crawler: Fix target branch field not set on ChangeEvent Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - [crawler] Correctly handle errors and do not commit new changes.
+- [crawler] Change target branch not field not set on ChangeEvent documents.
 
 ## [1.9.0] - 2023-09-16
 

--- a/src/Monocle/Backend/Documents.hs
+++ b/src/Monocle/Backend/Documents.hs
@@ -566,6 +566,7 @@ data EChangeEvent = EChangeEvent
   , echangeeventOnAuthor :: Author
   , echangeeventSelfMerged :: Maybe Bool
   , echangeeventBranch :: LText
+  , echangeeventTargetBranch :: LText
   , -- Set labels as a Maybe type because existing indexes do not have the event docs with labels
     -- TODO: implement a migration procedure in the Janitor and remove the 'Maybe' from this value
     echangeeventLabels :: Maybe [LText]

--- a/src/Monocle/Backend/Index.hs
+++ b/src/Monocle/Backend/Index.hs
@@ -478,6 +478,7 @@ toEChangeEvent ChangePB.ChangeEvent {..} =
         EChangeMergedEvent -> Just $ onAuthor == author
         _ -> Nothing
     , echangeeventBranch = changeEventBranch
+    , echangeeventTargetBranch = changeEventTargetBranch
     , echangeeventLabels = Just . toList $ changeEventLabels
     , echangeeventCreatedAt = T.toUTCTime $ fromMaybe (error "changeEventCreatedAt field is mandatory") changeEventCreatedAt
     , echangeeventOnCreatedAt = T.toUTCTime $ fromMaybe (error "changeEventOnCreatedAt field is mandatory") changeEventOnCreatedAt

--- a/src/Monocle/Backend/Provisioner.hs
+++ b/src/Monocle/Backend/Provisioner.hs
@@ -160,6 +160,7 @@ fakeChangeEvent from' to = do
       echangeeventAuthor = Nothing
       echangeeventSelfMerged = Nothing
       echangeeventBranch = ""
+      echangeeventTargetBranch = "main"
       echangeeventApproval = Nothing
       echangeeventTasksData = Nothing
       echangeeventLabels = Just []

--- a/src/Monocle/Backend/Test.hs
+++ b/src/Monocle/Backend/Test.hs
@@ -1313,6 +1313,7 @@ emptyEvent = EChangeEvent {..}
   echangeeventAuthor = Just fakeAuthor
   echangeeventOnAuthor = fakeAuthor
   echangeeventBranch = mempty
+  echangeeventTargetBranch = "main"
   echangeeventSelfMerged = Nothing
   echangeeventCreatedAt = fakeDate
   echangeeventOnCreatedAt = fakeDate


### PR DESCRIPTION
This change fixes an issue that happen when filtering by branch in the search query then resulting graphs are empty. This was because most of the graph related metrics computation relies on the ChangeEvent docs. Adding the missing field fixes that issue.

fix #1065