### PR TITLE
docker - healthcheck assumes /bin/sh

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -479,10 +479,14 @@ in rec {
 
     # Ensure the home directory is r/w for any uid
     rwHome = "mkdir -p -m 1777 ${home}";
+
+    # Ensure /bin/sh (docker healthcheck assumes /bin/sh)
+    binSh = "ln -s usr/bin/sh bin/sh";
+
   in pkgs.dockerTools.buildLayeredImage {
     name = "quay.io/change-metrics/monocle-exe";
     contents = [ monocle-wrapper ];
-    extraCommands = "${createPasswd} && ${rwHome}";
+    extraCommands = "${createPasswd} && ${rwHome} && ${binSh}";
     tag = "latest";
     created = "now";
     config = {


### PR DESCRIPTION
Here is the command executed in the container context:

```
/bin/sh -c curl --silent --fail localhost:9001/health || exit 1
```

Since the move to UBI 8 image, sh is available under /usr/bin/sh. This change ensures a link from /bin/sh to /usr/bin/sh.

Attempt to fix #1078