### PR TITLE
fix author search not working since last stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Removed
 ### Fixed
 
+- [web] authors search returning no results #1082
+
 ## [1.10.0] - 2023-11-06
 
 ### Added


### PR DESCRIPTION
Properly render the index name in the Form rendered for htmx.

fix #1082