### PR TITLE
Catch elasticsearch error within the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- [api] The API no longer dumps large decoding error to the stdout.
+  Exceptions from the elastic API are now intercepted and displayed in a nicer format.
+  In a future change, such errors will be indexed for proper debugging.
+
 ### Removed
 
 ### Fixed

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -152,7 +152,7 @@ usageJanitor =
       (eitherReader $ (first T.unpack . Config.mkIndexName) . T.pack)
       (long "workspace" <> O.help "Workspace name" <> metavar "WORKSPACE")
   crawlerNameOption = strOption (long "crawler-name" <> O.help "The crawler name" <> metavar "CRAWLER_NAME")
-  runOnWorkspace env action' workspace = runEff $ runLoggerEffect $ runElasticEffect env $ runEmptyQueryM workspace action'
+  runOnWorkspace env action' workspace = runEff $ runLoggerEffect $ runElasticEffect env $ runEmptyQueryM workspace $ dieOnEsError action'
   noWorkspace workspaceName = "Unable to find the workspace " <> Config.getIndexName workspaceName <> " in the Monocle config"
   janitorUpdateIdent = io <$> parser
    where

--- a/src/Effectful/Servant.hs
+++ b/src/Effectful/Servant.hs
@@ -27,7 +27,7 @@ runWarpServerSettingsContext settings cfg serverEff middleware = do
     ( \es ->
         Warp.runSettings settings (middleware (hoistEff @api es cfg serverEff))
     )
-  error "Warp exited"
+  error "Oops, the listening server (warp) exited, that should not have happened"
 
 hoistEff ::
   forall (api :: Type) (context :: [Type]) (es :: [Effect]).

--- a/src/Macroscope/Test.hs
+++ b/src/Macroscope/Test.hs
@@ -37,7 +37,7 @@ runLentilleM client action = do
 testCrawlingPoint :: Assertion
 testCrawlingPoint = do
   appEnv <- mkAppEnv fakeConfig
-  runAppEnv appEnv $ runEmptyQueryM fakeConfig do
+  runAppEnv appEnv $ runEmptyQueryM fakeConfig $ dieOnEsError do
     I.ensureIndexSetup
     let fakeChange1 =
           BT.fakeChange
@@ -124,7 +124,7 @@ testTaskDataMacroscope = withTestApi appEnv $ \client -> testAction client
           | otherwise = error $ "Unexpected product entity: " <> show project
     void $ runLentilleM client $ Macroscope.runStream apiKey indexName (CrawlerName crawlerName) (Macroscope.TaskDatas stream)
     -- Check task data got indexed
-    withTenantConfig fakeConfig do
+    withTenantConfig fakeConfig $ dieOnEsError do
       count <- withQuery taskDataQuery $ Streaming.length_ Q.scanSearchId
       liftIO (assertEqual "Task data got indexed by macroscope" count 1)
 

--- a/src/Monocle/Api/Server.hs
+++ b/src/Monocle/Api/Server.hs
@@ -94,7 +94,7 @@ updateIndex index wsRef = E.modifyMVar_ wsRef doUpdateIfNeeded
     Nothing -> error $ "Unknown workspace: " <> show (Config.getWorkspaceName index)
 
   refreshIndex :: Eff es ()
-  refreshIndex = do
+  refreshIndex = dieOnEsError do
     logInfo "RefreshIndex" ["index" .= Config.getWorkspaceName index]
     runRetry I.ensureIndexSetup
     traverse_ I.initCrawlerMetadata index.crawlers
@@ -171,7 +171,7 @@ loginLoginValidation _auth request = do
   validateOnIndex :: Text -> Config.Index -> MaybeT (Eff es) ()
   validateOnIndex username index = do
     let userQuery = Q.toUserTerm username
-    count <- lift $ runEmptyQueryM index $ withFilter [userQuery] Q.countDocs
+    count <- lift $ dieOnEsError $ runEmptyQueryM index $ withFilter [userQuery] Q.countDocs
     when (count > 0) mzero
 
 -- | /api/2/about endpoint
@@ -314,7 +314,7 @@ crawlerAddDoc _auth request = do
         pure (index, crawler)
 
   case requestE of
-    Right (index, crawler) -> runEmptyQueryM index do
+    Right (index, crawler) -> runEmptyQueryM index $ dieOnEsError do
       unless (V.null errors) do
         addErrors crawlerName (toEntity entity) errors
       case toEntity entity of
@@ -405,7 +405,7 @@ crawlerCommit _auth request = do
         pure (index, ts, toEntity entityPB)
 
   case requestE of
-    Right (index, ts, entity) -> runEmptyQueryM index $ do
+    Right (index, ts, entity) -> runEmptyQueryM index $ dieOnEsError $ do
       let date = Timestamp.toUTCTime ts
       logInfo "UpdatingEntity" ["crawler" .= crawlerName, "entity" .= entity, "date" .= date]
       -- TODO: check for CommitDateInferiorThanPrevious
@@ -445,7 +445,7 @@ crawlerCommitInfo _auth request = do
 
   case requestE of
     Right (index, worker, entityType) -> do
-      runEmptyQueryM index $ do
+      runEmptyQueryM index $ dieOnEsError do
         updateIndex index wsStatus
         toUpdateEntityM <- I.getLastUpdated worker (fromPBEnum entityType) offset
         case toUpdateEntityM of
@@ -487,7 +487,7 @@ searchSuggestions auth request = checkAuth auth . const $ do
   case tenantM of
     Just tenant -> do
       now <- getCurrentTime
-      runQueryM tenant (emptyQ now) $ Q.getSuggestions tenant
+      runQueryM tenant (emptyQ now) $ dieOnEsError $ Q.getSuggestions tenant
     Nothing ->
       -- Simply return empty suggestions in case of unknown tenant
       pure
@@ -531,7 +531,7 @@ searchAuthor auth request = checkAuth auth . const $ do
                   authorAliases = V.fromList $ from <$> aliases
                   authorGroups = V.fromList $ from <$> fromMaybe mempty groups
                in SearchPB.Author {..}
-      found <- runEmptyQueryM index $ I.searchAuthorCache . from $ authorRequestQuery
+      found <- runEmptyQueryM index $ dieOnEsError $ I.searchAuthorCache . from $ authorRequestQuery
       pure $ toSearchAuthor <$> found
     Nothing -> pure []
 
@@ -570,7 +570,7 @@ crawlerErrors auth request = checkAuth auth response
     requestE <- validateSearchRequest request.errorsRequestIndex request.errorsRequestQuery "nobody"
 
     case requestE of
-      Right (tenant, query) -> runQueryM tenant (Q.ensureMinBound query) $ do
+      Right (tenant, query) -> runQueryM tenant (Q.ensureMinBound query) $ dieOnEsError do
         logInfo "ListingErrors" ["index" .= request.errorsRequestIndex]
         errors <- toErrorsList <$> Q.crawlerErrors
         pure $ CrawlerPB.ErrorsResponse $ Just $ CrawlerPB.ErrorsResponseResultSuccess $ CrawlerPB.ErrorsList $ fromList errors
@@ -611,7 +611,7 @@ searchQuery auth request = checkAuth auth response
     requestE <- validateSearchRequest queryRequestIndex queryRequestQuery username
 
     case requestE of
-      Right (tenant, query) -> runQueryM tenant (Q.ensureMinBound query) $ do
+      Right (tenant, query) -> runQueryM tenant (Q.ensureMinBound query) $ dieOnEsError do
         let queryType = fromPBEnum queryRequestQueryType
         logInfo
           "Searching"
@@ -946,9 +946,10 @@ metricGet auth request = checkAuth auth response
       -- Unknown query
       _ -> handleError $ "Unknown metric: " <> from getRequestMetric
    where
-    runM :: Eff (MonoQuery : es) a -> Eff es a
-    runM = runQueryM tenant (Q.ensureMinBound query)
-    runMetric :: (TrendPB a, TopPB a, NumPB a) => Q.Metric (MonoQuery : es) a -> Eff es MetricPB.GetResponse
+    runM :: Eff (MonoQuery : Error ElasticError : es) a -> Eff es a
+    runM = dieOnEsError . runQueryM tenant (Q.ensureMinBound query)
+
+    runMetric :: (TrendPB a, TopPB a, NumPB a) => Q.Metric (MonoQuery : Error ElasticError : es) a -> Eff es MetricPB.GetResponse
     runMetric m = case getRequestOptions of
       Just (MetricPB.GetRequestOptionsTrend (MetricPB.Trend interval)) ->
         toTrendResult <$> runM (Q.runMetricTrend m $ fromPBTrendInterval $ from interval)

--- a/src/Monocle/Api/ServerHTMX.hs
+++ b/src/Monocle/Api/ServerHTMX.hs
@@ -10,7 +10,7 @@ import Monocle.Api.Server (searchAuthor)
 import Monocle.Backend.Documents (EDocType (ECachedAuthor))
 import Monocle.Backend.Queries (documentType)
 import Monocle.Config qualified as Config
-import Monocle.Effects (ApiEffects, esCountByIndex)
+import Monocle.Effects (ApiEffects, dieOnEsError, esCountByIndex)
 import Monocle.Env (tenantIndexName)
 import Monocle.Prelude
 import Monocle.Protob.Search (AuthorRequest (..))
@@ -59,7 +59,8 @@ searchAuthorsHandler auth (Just index) queryM = do
   indexVal :: Text
   indexVal = from index
   countCachedAuthors = do
-    resp <- esCountByIndex (tenantIndexName index) $ BH.CountQuery $ documentType ECachedAuthor
+    resp <- dieOnEsError do
+      esCountByIndex (tenantIndexName index) $ BH.CountQuery $ documentType ECachedAuthor
     case resp of
       Right (BH.CountResponse nat _) -> pure nat
       Left _ -> pure 0

--- a/src/Monocle/Api/Test.hs
+++ b/src/Monocle/Api/Test.hs
@@ -18,7 +18,7 @@ import Servant.Auth.Server (
   generateKey,
  )
 
-import Database.Bloodhound qualified as BH
+import Database.Bloodhound qualified as BH (BHEnv)
 import Effectful.Error.Static qualified as E
 import Effectful.Fail qualified as E
 import Effectful.Reader.Static qualified as E
@@ -69,7 +69,7 @@ withTestApi appEnv' testCb = bracket appEnv' cleanIndex runTest
           jwtCfg = appEnv.aOIDC.localJWTSettings
           cfg = jwtCfg :. cookieCfg :. EmptyContext
       traverse_
-        (\index -> runEmptyQueryM index I.ensureIndex)
+        (\index -> dieOnEsError $ runEmptyQueryM index I.ensureIndex)
         indexes
       unsafeEff $ \es ->
         let app = Effectful.Servant.hoistEff @RootAPI es cfg (rootServer cookieCfg)

--- a/src/Monocle/Backend/Provisioner.hs
+++ b/src/Monocle/Backend/Provisioner.hs
@@ -31,7 +31,7 @@ import Google.Protobuf.Timestamp qualified (fromUTCTime)
 import Monocle.Backend.Documents
 import Monocle.Backend.Test qualified as T
 import Monocle.Config (csConfig, getWorkspaces, lookupTenant, mkIndexName)
-import Monocle.Effects (getReloadConfig, runElasticEffect, runEmptyQueryM, runMonoConfig)
+import Monocle.Effects (dieOnEsError, getReloadConfig, runElasticEffect, runEmptyQueryM, runMonoConfig)
 import Monocle.Env (mkEnv)
 import Monocle.Prelude
 import Monocle.Protob.Search (TaskData (..))
@@ -50,7 +50,7 @@ runProvisioner configPath elasticUrl tenantName docCount = do
     case tenantM of
       Just tenant -> do
         bhEnv <- mkEnv elasticUrl
-        r <- runRetry $ runFail $ runElasticEffect bhEnv $ do
+        r <- runRetry $ runFail $ runElasticEffect bhEnv $ dieOnEsError do
           events <- liftIO $ createFakeEvents docCount
           runEmptyQueryM tenant $ T.indexScenario events
           logInfo "Provisionned" ["index" .= indexName, "doc count" .= length events]

--- a/src/Monocle/Backend/Queries.hs
+++ b/src/Monocle/Backend/Queries.hs
@@ -30,7 +30,7 @@ import Monocle.Effects
 import Proto3.Suite (Enumerated (Enumerated))
 
 -- Legacy wrappers
-simpleSearchLegacy :: (LoggerEffect :> es, ElasticEffect :> es, FromJSON a) => BH.IndexName -> BH.Search -> Eff es [BH.Hit a]
+simpleSearchLegacy :: (LoggerEffect :> es, Error ElasticError :> es, ElasticEffect :> es, FromJSON a) => BH.IndexName -> BH.Search -> Eff es [BH.Hit a]
 simpleSearchLegacy indexName search = BH.hits . BH.searchHits <$> esSearchLegacy indexName search
 
 -------------------------------------------------------------------------------
@@ -1778,7 +1778,7 @@ allMetrics :: [MetricInfo]
 allMetrics =
   map
     metricInfo
-    [ toJSON <$> metricChangesCreated @[ElasticEffect, LoggerEffect, MonoQuery]
+    [ toJSON <$> metricChangesCreated @[ElasticEffect, Error ElasticError, LoggerEffect, MonoQuery]
     , toJSON <$> metricChangesMerged
     , toJSON <$> metricChangesAbandoned
     , toJSON <$> metricChangesSelfMerged

--- a/src/Monocle/Effects.hs
+++ b/src/Monocle/Effects.hs
@@ -59,12 +59,15 @@ module Monocle.Effects where
 import Monocle.Prelude hiding (Reader, ask, local)
 
 import Control.Exception (finally)
+import Control.Exception.Base (ErrorCall (ErrorCall))
+import Control.Monad.Catch (catches)
+import Data.Text qualified as T
 import Monocle.Client qualified
 import Monocle.Config qualified
 import Network.HTTP.Client (HttpException (..))
 import Network.HTTP.Client qualified as HTTP
 
-import Effectful
+import Effectful as E
 import Effectful.Dispatch.Static (SideEffects (..), StaticRep, evalStaticRep, getStaticRep, localStaticRep)
 import Effectful.Dispatch.Static.Primitive qualified as EffStatic
 import Monocle.Effects.Compat ()
@@ -114,10 +117,10 @@ type ApiEffects es =
   )
 
 -- the effect necessary to run elastic request
-type IndexEffects es = (ElasticEffect :> es, LoggerEffect :> es)
+type IndexEffects es = (Error ElasticError :> es, ElasticEffect :> es, LoggerEffect :> es)
 
 -- the query handler :> es, previously known as QueryM
-type QEffects es = (ElasticEffect :> es, LoggerEffect :> es, MonoQuery :> es)
+type QEffects es = (ElasticEffect :> es, Error ElasticError :> es, LoggerEffect :> es, MonoQuery :> es)
 
 -- the macro handler :> es, previously known as LentilleM
 type CrawlerEffects es = (LoggerEffect :> es, MonoClientEffect :> es)
@@ -366,98 +369,143 @@ runElasticEffect bhEnv action = do
   -- bhEnv <- liftIO (BH.mkBHEnv <$> pure server <*> Monocle.Client.mkManager)
   evalStaticRep (ElasticEffect bhEnv) action
 
-esSearch :: (ElasticEffect :> es, ToJSON body, FromJSONField resp) => BH.IndexName -> body -> BHR.ScrollRequest -> Eff es (BH.SearchResult resp)
+-- | ElasticError are produced by the es client
+data ElasticError = ElasticError
+  { call :: Text
+  -- ^ The name of the action, e.g. 'search'.
+  , msg :: Text
+  -- ^ The error message from the client.
+  , req :: Text
+  -- ^ The request body JSON encoded.
+  , resp :: LByteString
+  -- ^ The api responde body.
+  }
+  deriving (Show)
+
+-- | This function runs a BH IO safely by catching EsProtocolExceptions (which contains json decoding errors).
+-- After using this function, a new Error effect is added to the 'es' constraint.
+-- Use 'runEsError' to discharge the new effect and access the final result 'a'.
+runBHIOSafe ::
+  HasCallStack =>
+  (ToJSON body, Error ElasticError :> es, ElasticEffect :> es) =>
+  -- | The action name to be recorded in the error
+  Text ->
+  -- | A copy of the body to be recorded in the error
+  body ->
+  -- | The bloodhound action
+  BH.BH IO a ->
+  Eff es a
+runBHIOSafe call bodyJSON act = do
+  ElasticEffect env <- getStaticRep
+  eRes <- unsafeEff_ ((Right <$> BH.runBH env act) `catches` [errorHandler, esHandler])
+  case eRes of
+    Right x -> pure x
+    Left e -> E.throwError e
+ where
+  toErr msg err = pure $ Left $ ElasticError call msg body err
+  errorHandler = Handler $ \(ErrorCall err) -> toErr (from err) "error called"
+  esHandler = Handler $ \(BH.EsProtocolException msg resp) -> toErr msg resp
+  body = decodeUtf8 $ encode bodyJSON
+
+-- | Safely remove (Error ElasticError) from the list of effect.
+runEsError :: Eff (Error ElasticError : es) a -> Eff es (Either (CallStack, ElasticError) a)
+runEsError = E.runError
+
+-- | Hard remove (Error ElasticError) from the list of effect by using 'error'
+-- This used to be the default behavior.
+dieOnEsError :: Eff (Error ElasticError : es) a -> Eff es a
+dieOnEsError act =
+  runEsError act >>= \case
+    Left (tb, err) ->
+      error
+        $ mconcat
+          [ err.call
+          , ": "
+          , err.msg
+          , ", req: "
+          , T.take 120 err.req
+          , ", resp: "
+          , -- cut the message to avoid filling the term. this needs to be indexed for proper debug
+            T.take 120 (decodeUtf8 err.resp)
+          , ", tb: "
+          , show tb
+          ]
+    Right x -> pure x
+
+esSearch :: (Error ElasticError :> es, ElasticEffect :> es, ToJSON body, FromJSONField resp) => BH.IndexName -> body -> BHR.ScrollRequest -> Eff es (BH.SearchResult resp)
 esSearch iname body scrollReq = do
-  ElasticEffect env <- getStaticRep
-  -- unsafeEff_ $ BH.runBH env $ BHR.search iname (trace (show $ encode body) body) scrollReq
-  unsafeEff_ $ BH.runBH env $ BHR.search iname body scrollReq
+  runBHIOSafe "esSearch" body $ BHR.search iname body scrollReq
 
-esAdvance :: (ElasticEffect :> es, FromJSON resp) => BH.ScrollId -> Eff es (BH.SearchResult resp)
+esAdvance :: (Error ElasticError :> es, ElasticEffect :> es, FromJSON resp) => BH.ScrollId -> Eff es (BH.SearchResult resp)
 esAdvance scroll = do
-  ElasticEffect env <- getStaticRep
-  unsafeEff_ $ BH.runBH env $ BHR.advance scroll
+  runBHIOSafe "esAdvance" scroll $ BHR.advance scroll
 
-esGetDocument :: ElasticEffect :> es => BH.IndexName -> BH.DocId -> Eff es (HTTP.Response LByteString)
+esGetDocument :: (Error ElasticError :> es, ElasticEffect :> es) => BH.IndexName -> BH.DocId -> Eff es (HTTP.Response LByteString)
 esGetDocument iname doc = do
-  ElasticEffect env <- getStaticRep
-  unsafeEff_ $ BH.runBH env $ BH.getDocument iname doc
+  runBHIOSafe "esGetDocument" doc $ BH.getDocument iname doc
 
-esCountByIndex :: ElasticEffect :> es => BH.IndexName -> BH.CountQuery -> Eff es (Either BH.EsError BH.CountResponse)
+esCountByIndex :: (Error ElasticError :> es, ElasticEffect :> es) => BH.IndexName -> BH.CountQuery -> Eff es (Either BH.EsError BH.CountResponse)
 esCountByIndex iname q = do
-  ElasticEffect env <- getStaticRep
-  unsafeEff_ $ BH.runBH env $ BH.countByIndex iname q
+  runBHIOSafe "esCountByIndex" q $ BH.countByIndex iname q
 
-esSearchHit :: ElasticEffect :> es => ToJSON body => BH.IndexName -> body -> Eff es [Json.Value]
+esSearchHit :: (Error ElasticError :> es, ElasticEffect :> es) => ToJSON body => BH.IndexName -> body -> Eff es [Json.Value]
 esSearchHit iname body = do
-  ElasticEffect env <- getStaticRep
-  unsafeEff_ $ BH.runBH env $ BHR.searchHit iname body
+  runBHIOSafe "esSearchHit" body $ BHR.searchHit iname body
 
-esScanSearch :: ElasticEffect :> es => FromJSON body => BH.IndexName -> BH.Search -> Eff es [BH.Hit body]
+esScanSearch :: (Error ElasticError :> es, ElasticEffect :> es) => FromJSON body => BH.IndexName -> BH.Search -> Eff es [BH.Hit body]
 esScanSearch iname search = do
-  ElasticEffect env <- getStaticRep
-  unsafeEff_ $ BH.runBH env $ BH.scanSearch iname search
+  runBHIOSafe "esScanSearch" search $ BH.scanSearch iname search
 
-esDeleteByQuery :: ElasticEffect :> es => BH.IndexName -> BH.Query -> Eff es BH.Reply
+esDeleteByQuery :: (Error ElasticError :> es, ElasticEffect :> es) => BH.IndexName -> BH.Query -> Eff es BH.Reply
 esDeleteByQuery iname q = do
-  ElasticEffect env <- getStaticRep
-  unsafeEff_ $ BH.runBH env $ BH.deleteByQuery iname q
+  runBHIOSafe "esDeleteByQuery" q $ BH.deleteByQuery iname q
 
-esCreateIndex :: ElasticEffect :> es => BH.IndexSettings -> BH.IndexName -> Eff es ()
+esCreateIndex :: (Error ElasticError :> es, ElasticEffect :> es) => BH.IndexSettings -> BH.IndexName -> Eff es ()
 esCreateIndex is iname = do
-  ElasticEffect env <- getStaticRep
   -- TODO: check for error
-  unsafeEff_ $ void $ BH.runBH env $ BH.createIndex is iname
+  void $ runBHIOSafe "esCreateIndex" iname $ BH.createIndex is iname
 
-esIndexDocument :: ToJSON body => ElasticEffect :> es => BH.IndexName -> BH.IndexDocumentSettings -> body -> BH.DocId -> Eff es (HTTP.Response LByteString)
+esIndexDocument :: (ToJSON body, Error ElasticError :> es, ElasticEffect :> es) => BH.IndexName -> BH.IndexDocumentSettings -> body -> BH.DocId -> Eff es (HTTP.Response LByteString)
 esIndexDocument indexName docSettings body docId = do
-  ElasticEffect env <- getStaticRep
-  unsafeEff_ $ BH.runBH env $ BH.indexDocument indexName docSettings body docId
+  runBHIOSafe "esIndexDocument" body $ BH.indexDocument indexName docSettings body docId
 
-esPutMapping :: ElasticEffect :> es => ToJSON mapping => BH.IndexName -> mapping -> Eff es ()
+esPutMapping :: (Error ElasticError :> es, ElasticEffect :> es) => ToJSON mapping => BH.IndexName -> mapping -> Eff es ()
 esPutMapping iname mapping = do
-  ElasticEffect env <- getStaticRep
-  unsafeEff_ $ void $ BH.runBH env $ BH.putMapping iname mapping
+  -- TODO: check for error
+  void $ runBHIOSafe "esPutMapping" mapping $ BH.putMapping iname mapping
 
-esIndexExists :: ElasticEffect :> es => BH.IndexName -> Eff es Bool
+esIndexExists :: (Error ElasticError :> es, ElasticEffect :> es) => BH.IndexName -> Eff es Bool
 esIndexExists iname = do
-  ElasticEffect env <- getStaticRep
-  unsafeEff_ $ BH.runBH env $ BH.indexExists iname
+  runBHIOSafe "esIndexExists" iname $ BH.indexExists iname
 
-esDeleteIndex :: ElasticEffect :> es => BH.IndexName -> Eff es (HTTP.Response LByteString)
+esDeleteIndex :: (Error ElasticError :> es, ElasticEffect :> es) => BH.IndexName -> Eff es (HTTP.Response LByteString)
 esDeleteIndex iname = do
-  ElasticEffect env <- getStaticRep
-  unsafeEff_ $ BH.runBH env $ BH.deleteIndex iname
+  runBHIOSafe "esDeleteIndex" iname $ BH.deleteIndex iname
 
-esSettings :: ElasticEffect :> es => ToJSON body => BH.IndexName -> body -> Eff es ()
+esSettings :: (Error ElasticError :> es, ElasticEffect :> es) => ToJSON body => BH.IndexName -> body -> Eff es ()
 esSettings iname body = do
-  ElasticEffect env <- getStaticRep
-  unsafeEff_ $ BH.runBH env $ BHR.settings iname body
+  runBHIOSafe "esSettings" body $ BHR.settings iname body
 
-esRefreshIndex :: ElasticEffect :> es => BH.IndexName -> Eff es (HTTP.Response LByteString)
+esRefreshIndex :: (Error ElasticError :> es, ElasticEffect :> es) => BH.IndexName -> Eff es (HTTP.Response LByteString)
 esRefreshIndex iname = do
-  ElasticEffect env <- getStaticRep
-  unsafeEff_ $ BH.runBH env $ BH.refreshIndex iname
+  runBHIOSafe "esRefreshIndex" iname $ BH.refreshIndex iname
 
-esDocumentExists :: ElasticEffect :> es => BH.IndexName -> BH.DocId -> Eff es Bool
+esDocumentExists :: (Error ElasticError :> es, ElasticEffect :> es) => BH.IndexName -> BH.DocId -> Eff es Bool
 esDocumentExists iname doc = do
-  ElasticEffect env <- getStaticRep
-  unsafeEff_ $ BH.runBH env $ BH.documentExists iname doc
+  runBHIOSafe "esDocumentExists" doc $ BH.documentExists iname doc
 
-esBulk :: ElasticEffect :> es => V.Vector BulkOperation -> Eff es BH.Reply
+esBulk :: (Error ElasticError :> es, ElasticEffect :> es) => V.Vector BulkOperation -> Eff es BH.Reply
 esBulk ops = do
-  ElasticEffect env <- getStaticRep
-  unsafeEff_ $ BH.runBH env $ BH.bulk ops
+  runBHIOSafe "esBulk" ([] :: [Bool]) $ BH.bulk ops
 
-esUpdateDocument :: ElasticEffect :> es => ToJSON a => BH.IndexName -> BH.IndexDocumentSettings -> a -> DocId -> Eff es BH.Reply
+esUpdateDocument :: (Error ElasticError :> es, ElasticEffect :> es) => ToJSON a => BH.IndexName -> BH.IndexDocumentSettings -> a -> DocId -> Eff es BH.Reply
 esUpdateDocument iname ids body doc = do
-  ElasticEffect env <- getStaticRep
-  unsafeEff_ $ BH.runBH env $ BH.updateDocument iname ids body doc
+  runBHIOSafe "esUpdateDocument" body $ BH.updateDocument iname ids body doc
 
 -- Legacy wrappers
-esSearchLegacy :: (LoggerEffect :> es, ElasticEffect :> es, FromJSON a) => BH.IndexName -> BH.Search -> Eff es (BH.SearchResult a)
+esSearchLegacy :: (LoggerEffect :> es, Error ElasticError :> es, ElasticEffect :> es, FromJSON a) => BH.IndexName -> BH.Search -> Eff es (BH.SearchResult a)
 esSearchLegacy indexName search = do
-  ElasticEffect env <- getStaticRep
-  (rawResp, resp) <- unsafeEff_ $ BH.runBH env do
+  (rawResp, resp) <- runBHIOSafe "esSearchLegacy" search do
     -- logText . decodeUtf8 . encode $ search
     rawResp <- BH.searchByIndex indexName search
     -- logText $ show rawResp

--- a/src/Monocle/Main.hs
+++ b/src/Monocle/Main.hs
@@ -157,8 +157,9 @@ run' ApiConfig {..} aplogger = E.runConcurrent $ runLoggerEffect do
 
   bhEnv <- mkEnv elasticUrl
   r <- runRetry $ E.runFail $ runElasticEffect bhEnv do
-    traverse_ (`runEmptyQueryM` I.ensureIndex) workspaces
-    runMonoQuery (MonoQueryEnv (QueryConfig conf) (mkQuery [])) I.ensureConfigIndex
+    dieOnEsError do
+      traverse_ (`runEmptyQueryM` I.ensureIndex) workspaces
+      runMonoQuery (MonoQueryEnv (QueryConfig conf) (mkQuery [])) I.ensureConfigIndex
 
     let settings = Warp.setPort port $ Warp.setLogger httpLogger Warp.defaultSettings
         jwtCfg = localJWTSettings

--- a/src/Monocle/Main.hs
+++ b/src/Monocle/Main.hs
@@ -181,9 +181,7 @@ run' ApiConfig {..} aplogger = E.runConcurrent $ runLoggerEffect do
         cfg
         (rootServer cookieCfg)
         middleware
-  case r of
-    Left e -> error (show e)
-    Right e -> error (show e)
+  error $ "The impossible has happened, the server stopped: " <> show r
  where
   corsPolicy =
     simpleCorsResourcePolicy {corsRequestHeaders = ["content-type"]}


### PR DESCRIPTION
This change improves error reporting when the elastic client throws errors. The implementation is done in the `Monocle.Effects` module.