### PR TITLE
index: change the groups to optional for migration purpose

### DIFF
--- a/src/Monocle/Backend/Documents.hs
+++ b/src/Monocle/Backend/Documents.hs
@@ -36,7 +36,7 @@ import Monocle.Protob.Search qualified as SearchPB
 data Author = Author
   { authorMuid :: LText
   , authorUid :: LText
-  , authorGroups :: [LText]
+  , authorGroups :: Maybe [LText]
   }
   deriving (Show, Eq, Generic)
 
@@ -51,7 +51,7 @@ instance From ChangePB.Ident Author where
     Author
       { authorMuid = identMuid
       , authorUid = identUid
-      , authorGroups = toList identGroups
+      , authorGroups = Just $ toList identGroups
       }
 
 fromMaybeIdent :: Maybe ChangePB.Ident -> Author

--- a/src/Monocle/Backend/Index.hs
+++ b/src/Monocle/Backend/Index.hs
@@ -502,7 +502,7 @@ toAuthor (Just ChangePB.Ident {..}) =
   Monocle.Backend.Documents.Author
     { authorMuid = identMuid
     , authorUid = identUid
-    , authorGroups = toList identGroups
+    , authorGroups = Just $ toList identGroups
     }
 toAuthor Nothing =
   Monocle.Backend.Documents.Author

--- a/src/Monocle/Backend/Janitor.hs
+++ b/src/Monocle/Backend/Janitor.hs
@@ -28,7 +28,7 @@ import Streaming.Prelude qualified as Streaming
 
 updateAuthor :: Config.Index -> D.Author -> D.Author
 updateAuthor index author@D.Author {..} = case getIdent of
-  Just (identMuid, identGroups) -> D.Author (from identMuid) authorUid (from <$> identGroups)
+  Just (identMuid, identGroups) -> D.Author (from identMuid) authorUid (Just $ from <$> identGroups)
   Nothing
     | newMuid /= from authorMuid -> D.Author (from newMuid) authorUid authorGroups
     | otherwise -> author

--- a/src/Monocle/Backend/Test.hs
+++ b/src/Monocle/Backend/Test.hs
@@ -237,7 +237,7 @@ testIndexChanges = withTenant doTest
         , echangeTitle = title
         , echangeRepositoryFullname = "fakerepo"
         , echangeUrl = "https://fakehost/change/" <> show number
-        , echangeAuthor = Author "John" "John" ["dev", "core"]
+        , echangeAuthor = Author "John" "John" (Just ["dev", "core"])
         }
 
 testIndexEvents :: Assertion
@@ -609,7 +609,7 @@ testJanitorUpdateIdents = do
       , idents = Just [Config.Ident ["github.com/john"] (Just ["dev", "core"]) "John Doe"]
       , search_aliases = Nothing
       }
-  expectedAuthor = Author "John Doe" "github.com/john" ["dev", "core"]
+  expectedAuthor = Author "John Doe" "github.com/john" (Just ["dev", "core"])
 
   doUpdateIndentOnEventsTest :: Eff [MonoQuery, ElasticEffect, LoggerEffect, IOE] ()
   doUpdateIndentOnEventsTest = E.runFailIO $ dieOnEsError do
@@ -623,7 +623,7 @@ testJanitorUpdateIdents = do
     evt2' <- I.getChangeEventById $ I.getEventDocId evt2
     assertEqual' "Ensure event not changed" evt2' $ Just evt2
    where
-    evt1 = mkEventWithAuthor "e1" (Author "john" "github.com/john" ["not-core"])
+    evt1 = mkEventWithAuthor "e1" (Author "john" "github.com/john" (Just ["not-core"]))
     evt2 = mkEventWithAuthor "e2" (Author "paul" "github.com/paul" mempty)
     mkEventWithAuthor ::
       -- eventId


### PR DESCRIPTION
When deploying the new schema, the existing documents does not have a groups attribute set, so this change reflect that to the data type.