### PR TITLE
Fix missing EError doc in AllEventTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 ### Removed
 ### Fixed
 
+- [janitor] `update-idents` unables to process when some Error docs are in the index.
+
 ## [1.11.0] - 2024-01-12
 
 ### Added

--- a/src/Monocle/Backend/Documents.hs
+++ b/src/Monocle/Backend/Documents.hs
@@ -319,6 +319,7 @@ instance FromJSON EChangeState where
       )
 
 -- | When adding new document type, update the `instance FromJSON EDocType` too.
+-- | and please make sure to update `allEventTypes` accordingly
 data EDocType
   = EChangeCreatedEvent
   | EChangeMergedEvent
@@ -339,7 +340,7 @@ data EDocType
 
 allEventTypes :: [EDocType]
 allEventTypes =
-  filter (`notElem` [EChangeDoc, EOrphanTaskData, ECachedAuthor]) [minBound .. maxBound]
+  filter (`notElem` [EChangeDoc, EOrphanTaskData, ECachedAuthor, EErrorDoc]) [minBound .. maxBound]
 
 instance From EDocType Text where
   from = \case


### PR DESCRIPTION
This fixes an issue reported here:
https://github.com/change-metrics/monocle/issues/1084

monocle: esAdvance: Original error was: Error in $.hits.hits[2905]['_source']: parsing Monocle.Backend.Janitor.EChangeEventAuthors(EChangeEventAuthors) failed, key "id" not found Error parse failure was: Error in $: key "status" not found, req: "FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFkJtNFFLQW82UjhDR21YRVRpTnNuVXcAAAAAAAAA8xZmMDFyRzVFeVJjR2VVUFVZMGNxZ0t, resp: {"_scroll_id":"FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFkJtNFFLQW82UjhDR21YRVRpTnNuVXcAAAAAAAAA8xZmMDFyRzVFeVJjR, tb: [("throwError",SrcLoc {srcLocPackage = "monocle-1.11.0-2ShLfwfFjyo1H0paLD2SMi", srcLocModule = "Monocle.Effects", srcLocFile = "src/Monocle/Effects.hs", srcLocStartLine = 403, srcLocStartCol = 15, srcLocEndLine = 403, srcLocEndCol = 27}),("runBHIOSafe",SrcLoc {srcLocPackage = "monocle-1.11.0-2ShLfwfFjyo1H0paLD2SMi", srcLocModule = "Monocle.Effects", srcLocFile = "src/Monocle/Effects.hs", srcLocStartLine = 445, srcLocStartCol = 3, srcLocEndLine = 445, srcLocEndCol = 14})] CallStack (from HasCallStack):
  error, called at src/Relude/Debug.hs:289:11 in relude-1.2.0.0-Jiwa4gfuZvkK1snRof3V:Relude.Debug
  error, called at src/Monocle/Effects.hs:420:7 in monocle-1.11.0-2ShLfwfFjyo1H0paLD2SMi:Monocle.Effects