### PR TITLE
Ensure Github PR fetching repo not found non fatal for stream

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -44,15 +44,15 @@ jobs:
       - name: Set Monocle compose image to latest
         run: "echo \"COMPOSE_MONOCLE_VERSION=latest\" > .env"
       - name: Start Monocle compose
-        run: docker-compose up -d
+        run: docker compose up -d
       - name: Wait for services to start
         run: sleep 45
       - name: Display docker-compose ps
-        run: docker-compose ps
+        run: docker compose ps
       - name: Display docker-compose logs
-        run: docker-compose logs
+        run: docker compose logs
       - name: Check services are running
-        run: "test -z \"$(sudo docker-compose ps -a | grep Exit)\""
+        run: "test -z \"$(sudo docker compose ps -a | grep Exit)\""
       - name: Check api service through nginx
         run: "curl -s --fail -H 'Content-type: application/json' http://localhost:8080/api/2/get_workspaces -d '{}' | grep 'workspaces'"
       - name: Check web service to fetch web app

--- a/.github/workflows/mkCI.dhall
+++ b/.github/workflows/mkCI.dhall
@@ -91,7 +91,7 @@ in  { GithubActions
         }
       , GithubActions.Step::{
         , name = Some "Start Monocle compose"
-        , run = Some "docker-compose up -d"
+        , run = Some "docker compose up -d"
         }
       , GithubActions.Step::{
         , name = Some "Wait for services to start"
@@ -99,15 +99,15 @@ in  { GithubActions
         }
       , GithubActions.Step::{
         , name = Some "Display docker-compose ps"
-        , run = Some "docker-compose ps"
+        , run = Some "docker compose ps"
         }
       , GithubActions.Step::{
         , name = Some "Display docker-compose logs"
-        , run = Some "docker-compose logs"
+        , run = Some "docker compose logs"
         }
       , GithubActions.Step::{
         , name = Some "Check services are running"
-        , run = Some "test -z \"\$(sudo docker-compose ps -a | grep Exit)\""
+        , run = Some "test -z \"\$(sudo docker compose ps -a | grep Exit)\""
         }
       , GithubActions.Step::{
         , name = Some "Check api service through nginx"

--- a/.github/workflows/publish-master.yaml
+++ b/.github/workflows/publish-master.yaml
@@ -45,15 +45,15 @@ jobs:
       - name: Set Monocle compose image to latest
         run: "echo \"COMPOSE_MONOCLE_VERSION=latest\" > .env"
       - name: Start Monocle compose
-        run: docker-compose up -d
+        run: docker compose up -d
       - name: Wait for services to start
         run: sleep 45
       - name: Display docker-compose ps
-        run: docker-compose ps
+        run: docker compose ps
       - name: Display docker-compose logs
-        run: docker-compose logs
+        run: docker compose logs
       - name: Check services are running
-        run: "test -z \"$(sudo docker-compose ps -a | grep Exit)\""
+        run: "test -z \"$(sudo docker compose ps -a | grep Exit)\""
       - name: Check api service through nginx
         run: "curl -s --fail -H 'Content-type: application/json' http://localhost:8080/api/2/get_workspaces -d '{}' | grep 'workspaces'"
       - name: Check web service to fetch web app

--- a/.github/workflows/publish-tag.yaml
+++ b/.github/workflows/publish-tag.yaml
@@ -45,15 +45,15 @@ jobs:
       - name: Set Monocle compose image to latest
         run: "echo \"COMPOSE_MONOCLE_VERSION=latest\" > .env"
       - name: Start Monocle compose
-        run: docker-compose up -d
+        run: docker compose up -d
       - name: Wait for services to start
         run: sleep 45
       - name: Display docker-compose ps
-        run: docker-compose ps
+        run: docker compose ps
       - name: Display docker-compose logs
-        run: docker-compose logs
+        run: docker compose logs
       - name: Check services are running
-        run: "test -z \"$(sudo docker-compose ps -a | grep Exit)\""
+        run: "test -z \"$(sudo docker compose ps -a | grep Exit)\""
       - name: Check api service through nginx
         run: "curl -s --fail -H 'Content-type: application/json' http://localhost:8080/api/2/get_workspaces -d '{}' | grep 'workspaces'"
       - name: Check web service to fetch web app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
 ## [master]
 
 ### Added
 ### Changed
 ### Removed
 ### Fixed
+
+- [crawler] github PR crawler raise a fatal StreamError when a repository is not found (#1112)
 
 ## [1.11.1] - 2024-02-13
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ A GitHub provider settings
 `github_organization` is the only mandatory key. If `github_repositories` is not specified then
 the crawler will crawl the whole organization repositories. If specified then it will crawl only
 the listed repositories. To crawl repositories from a personnal GitHub account, you need to set
-`github_organization` to you account name and list repositories under the `github_repositories` key.
+`github_organization` to the account name and list repositories under the `github_repositories` key.
 
 `github_url` might be specified in case of an alternate url. Default is "https://github.com/api/graphql".
 

--- a/src/Lentille.hs
+++ b/src/Lentille.hs
@@ -115,6 +115,7 @@ data LentilleErrorKind
   | RequestError GraphQLError
   | RateLimitInfoError GraphQLError
   | PartialErrors Value
+  | EntityRemoved
   deriving (Show, Generic, ToJSON)
 
 yieldStreamError :: TimeEffect :> es => LentilleErrorKind -> LentilleStream es a

--- a/src/Lentille/GitHub/Issues.hs
+++ b/src/Lentille/GitHub/Issues.hs
@@ -97,7 +97,7 @@ transformRateLimit (GetLinkedIssuesRateLimit used remaining (DateTime resetAtTex
     Just resetAt -> RateLimit {..}
     Nothing -> error $ "Unable to parse the resetAt date string: " <> resetAtText
 
-transformResponse :: GetLinkedIssues -> (PageInfo, Maybe RateLimit, DynErr, [TaskData])
+transformResponse :: GetLinkedIssues -> (PageInfo, Maybe RateLimit, GraphResponseResult, [TaskData])
 transformResponse searchResult =
   case searchResult of
     GetLinkedIssues

--- a/src/Lentille/GitHub/Issues.hs
+++ b/src/Lentille/GitHub/Issues.hs
@@ -97,7 +97,7 @@ transformRateLimit (GetLinkedIssuesRateLimit used remaining (DateTime resetAtTex
     Just resetAt -> RateLimit {..}
     Nothing -> error $ "Unable to parse the resetAt date string: " <> resetAtText
 
-transformResponse :: GetLinkedIssues -> (PageInfo, Maybe RateLimit, [Text], [TaskData])
+transformResponse :: GetLinkedIssues -> (PageInfo, Maybe RateLimit, DynErr, [TaskData])
 transformResponse searchResult =
   case searchResult of
     GetLinkedIssues
@@ -110,7 +110,7 @@ transformResponse searchResult =
         let newTaskDataE = concatMap mkTaskData issues
          in ( PageInfo hasNextPage' endCursor' (Just issueCount')
             , transformRateLimit <$> rateLimitM
-            , lefts newTaskDataE
+            , UnknownErr $ lefts newTaskDataE
             , rights newTaskDataE
             )
     respOther -> error ("Invalid response: " <> show respOther)

--- a/src/Lentille/GitHub/Organization.hs
+++ b/src/Lentille/GitHub/Organization.hs
@@ -36,7 +36,7 @@ transformRateLimit (GetProjectsRateLimit used remaining (DateTime resetAtText)) 
     Just resetAt -> RateLimit {..}
     Nothing -> error $ "Unable to parse the resetAt date string: " <> resetAtText
 
-transformResponse :: GetProjects -> (PageInfo, Maybe RateLimit, [Text], [Project])
+transformResponse :: GetProjects -> (PageInfo, Maybe RateLimit, DynErr, [Project])
 transformResponse result =
   case result of
     GetProjects
@@ -52,13 +52,13 @@ transformResponse result =
         ) ->
         ( PageInfo hasNextPage endCursor (Just totalCount)
         , transformRateLimit <$> rateLimitM
-        , []
+        , NoErr
         , getRepos orgRepositories
         )
     _anyOtherResponse ->
       ( PageInfo False Nothing Nothing
       , Nothing
-      , ["Unknown GetProjects response: " <> show result]
+      , UnknownErr ["Unknown GetProjects response: " <> show result]
       , []
       )
  where

--- a/src/Lentille/GitHub/Organization.hs
+++ b/src/Lentille/GitHub/Organization.hs
@@ -36,7 +36,7 @@ transformRateLimit (GetProjectsRateLimit used remaining (DateTime resetAtText)) 
     Just resetAt -> RateLimit {..}
     Nothing -> error $ "Unable to parse the resetAt date string: " <> resetAtText
 
-transformResponse :: GetProjects -> (PageInfo, Maybe RateLimit, DynErr, [Project])
+transformResponse :: GetProjects -> (PageInfo, Maybe RateLimit, GraphResponseResult, [Project])
 transformResponse result =
   case result of
     GetProjects

--- a/src/Lentille/GitHub/PullRequests.hs
+++ b/src/Lentille/GitHub/PullRequests.hs
@@ -66,7 +66,7 @@ transformResponse ::
   (Text -> Maybe Config.IdentUG) ->
   -- The response payload
   GetProjectPullRequests ->
-  (PageInfo, Maybe RateLimit, [Text], [Changes])
+  (PageInfo, Maybe RateLimit, DynErr, [Changes])
 transformResponse host identCB result = do
   let process resp rateLimit = case resp of
         ( Just
@@ -79,11 +79,17 @@ transformResponse host identCB result = do
               )
           ) ->
             let totalCount = Just totalCount'
-             in (PageInfo {..}, rateLimit, [], mapMaybe transPR (catMaybes projectPRs))
-        _anyOtherResponse ->
+             in (PageInfo {..}, rateLimit, NoErr, mapMaybe transPR (catMaybes projectPRs))
+        Just _ ->
           ( PageInfo False Nothing Nothing
           , Nothing
-          , ["Unknown GetProjectPullRequests response: " <> show result]
+          , UnknownErr ["Unknown GetProjectPullRequests response: " <> show result]
+          , []
+          )
+        Nothing ->
+          ( PageInfo False Nothing Nothing
+          , Nothing
+          , NoRepo
           , []
           )
   case result of

--- a/src/Lentille/GitHub/PullRequests.hs
+++ b/src/Lentille/GitHub/PullRequests.hs
@@ -66,7 +66,7 @@ transformResponse ::
   (Text -> Maybe Config.IdentUG) ->
   -- The response payload
   GetProjectPullRequests ->
-  (PageInfo, Maybe RateLimit, DynErr, [Changes])
+  (PageInfo, Maybe RateLimit, GraphResponseResult, [Changes])
 transformResponse host identCB result = do
   let process resp rateLimit = case resp of
         ( Just

--- a/src/Lentille/GitHub/UserPullRequests.hs
+++ b/src/Lentille/GitHub/UserPullRequests.hs
@@ -63,7 +63,7 @@ transformResponse ::
   (Text -> Maybe Config.IdentUG) ->
   -- The response payload
   GetUserPullRequests ->
-  (PageInfo, Maybe RateLimit, [Text], [Changes])
+  (PageInfo, Maybe RateLimit, DynErr, [Changes])
 transformResponse host identCB result = do
   let process resp rateLimit = case resp of
         ( Just
@@ -76,11 +76,11 @@ transformResponse host identCB result = do
               )
           ) ->
             let totalCount = Just totalCount'
-             in (PageInfo {..}, rateLimit, [], mapMaybe transPR (catMaybes projectPRs))
+             in (PageInfo {..}, rateLimit, NoErr, mapMaybe transPR (catMaybes projectPRs))
         _anyOtherResponse ->
           ( PageInfo False Nothing Nothing
           , Nothing
-          , ["Unknown GetUserPullRequests response: " <> show result]
+          , UnknownErr ["Unknown GetUserPullRequests response: " <> show result]
           , []
           )
   case result of

--- a/src/Lentille/GitHub/UserPullRequests.hs
+++ b/src/Lentille/GitHub/UserPullRequests.hs
@@ -63,7 +63,7 @@ transformResponse ::
   (Text -> Maybe Config.IdentUG) ->
   -- The response payload
   GetUserPullRequests ->
-  (PageInfo, Maybe RateLimit, DynErr, [Changes])
+  (PageInfo, Maybe RateLimit, GraphResponseResult, [Changes])
 transformResponse host identCB result = do
   let process resp rateLimit = case resp of
         ( Just

--- a/src/Lentille/GitHub/Watching.hs
+++ b/src/Lentille/GitHub/Watching.hs
@@ -54,13 +54,13 @@ transformResponse result = do
               Nothing -> error $ "Unable to parse the resetAt date string: " <> resetAtText
          in ( Lentille.GraphQL.PageInfo hasNextPage endCursor (Just totalCount)
             , Just rateLimit
-            , []
+            , Lentille.GraphQL.NoErr
             , getRepos watchedRepositories
             )
     _anyOtherResponse ->
       ( Lentille.GraphQL.PageInfo False Nothing Nothing
       , Nothing
-      , ["Unknown GetWatched response: " <> show result]
+      , Lentille.GraphQL.UnknownErr ["Unknown GetWatched response: " <> show result]
       , []
       )
  where

--- a/src/Lentille/GitLab/Group.hs
+++ b/src/Lentille/GitLab/Group.hs
@@ -43,7 +43,7 @@ streamGroupProjects client fullPath =
  where
   mkArgs _ = GetGroupProjectsArgs (ID fullPath)
 
-transformResponse :: GetGroupProjects -> (PageInfo, Maybe RateLimit, DynErr, [Project])
+transformResponse :: GetGroupProjects -> (PageInfo, Maybe RateLimit, GraphResponseResult, [Project])
 transformResponse result =
   case result of
     GetGroupProjects

--- a/src/Lentille/GitLab/Group.hs
+++ b/src/Lentille/GitLab/Group.hs
@@ -43,7 +43,7 @@ streamGroupProjects client fullPath =
  where
   mkArgs _ = GetGroupProjectsArgs (ID fullPath)
 
-transformResponse :: GetGroupProjects -> (PageInfo, Maybe RateLimit, [Text], [Project])
+transformResponse :: GetGroupProjects -> (PageInfo, Maybe RateLimit, DynErr, [Project])
 transformResponse result =
   case result of
     GetGroupProjects
@@ -57,13 +57,13 @@ transformResponse result =
         ) ->
         ( PageInfo hasNextPage endCursor Nothing
         , Nothing
-        , []
+        , NoErr
         , getFullPath <$> cleanMaybeMNodes nodes
         )
     _anyOtherResponse ->
       ( PageInfo False Nothing Nothing
       , Nothing
-      , ["Unknown GetGroupProjects response: " <> show result]
+      , UnknownErr ["Unknown GetGroupProjects response: " <> show result]
       , []
       )
  where

--- a/src/Lentille/GitLab/MergeRequests.hs
+++ b/src/Lentille/GitLab/MergeRequests.hs
@@ -125,7 +125,7 @@ transformResponse ::
   -- A callback to get Ident ID from an alias
   (Text -> Maybe Config.IdentUG) ->
   GetProjectMergeRequests ->
-  (PageInfo, Maybe RateLimit, DynErr, [(Change, [ChangeEvent])])
+  (PageInfo, Maybe RateLimit, GraphResponseResult, [(Change, [ChangeEvent])])
 transformResponse host getIdentIdCB result =
   case result of
     GetProjectMergeRequests

--- a/src/Lentille/GitLab/MergeRequests.hs
+++ b/src/Lentille/GitLab/MergeRequests.hs
@@ -125,7 +125,7 @@ transformResponse ::
   -- A callback to get Ident ID from an alias
   (Text -> Maybe Config.IdentUG) ->
   GetProjectMergeRequests ->
-  (PageInfo, Maybe RateLimit, [Text], [(Change, [ChangeEvent])])
+  (PageInfo, Maybe RateLimit, DynErr, [(Change, [ChangeEvent])])
 transformResponse host getIdentIdCB result =
   case result of
     GetProjectMergeRequests
@@ -144,13 +144,13 @@ transformResponse host getIdentIdCB result =
         ) ->
         ( PageInfo hasNextPage endCursor (Just count)
         , Nothing
-        , []
+        , NoErr
         , extract shortName fullName <$> catMaybes nodes
         )
     _anyOtherResponse ->
       ( PageInfo False Nothing Nothing
       , Nothing
-      , ["Unknown GetProjectMergeRequests response: " <> show result]
+      , UnknownErr ["Unknown GetProjectMergeRequests response: " <> show result]
       , []
       )
  where

--- a/src/Lentille/GraphQL.hs
+++ b/src/Lentille/GraphQL.hs
@@ -281,7 +281,7 @@ streamFetch client@GraphClient {..} mkArgs StreamFetchOptParams {..} transformRe
 
         _ <- case dynErrors of
           UnknownErr decodingErrors -> yieldStreamError $ DecodeError decodingErrors
-          NoRepo -> yieldStreamError $ EntityRemoved
+          NoRepo -> yieldStreamError EntityRemoved
           NoErr -> pure ()
 
         -- Yield the results

--- a/src/Lentille/GraphQL.hs
+++ b/src/Lentille/GraphQL.hs
@@ -24,7 +24,7 @@ module Lentille.GraphQL (
   GraphResponse,
   GraphResp,
   GraphError,
-  DynErr (..),
+  GraphResponseResult (..),
   RateLimit (..),
   PageInfo (..),
   StreamFetchOptParams (..),
@@ -45,9 +45,9 @@ import Monocle.Effects
 
 type GraphEffects es = (LoggerEffect :> es, HttpEffect :> es, PrometheusEffect :> es, TimeEffect :> es, Retry :> es, Concurrent :> es, Fail :> es)
 
-data DynErr = NoRepo | UnknownErr [Text] | NoErr
+data GraphResponseResult = NoRepo | UnknownErr [Text] | NoErr
 
-type GraphResponse a = (PageInfo, Maybe RateLimit, DynErr, a)
+type GraphResponse a = (PageInfo, Maybe RateLimit, GraphResponseResult, a)
 
 -------------------------------------------------------------------------------
 -- Constants
@@ -204,7 +204,7 @@ streamFetch ::
   (Maybe Int -> Maybe Text -> Args a) ->
   StreamFetchOptParams es a ->
   -- | query result adapter
-  (a -> (PageInfo, Maybe RateLimit, DynErr, [b])) ->
+  (a -> (PageInfo, Maybe RateLimit, GraphResponseResult, [b])) ->
   LentilleStream es b
 streamFetch client@GraphClient {..} mkArgs StreamFetchOptParams {..} transformResponse = startFetch
  where

--- a/src/Lentille/GraphQL.hs
+++ b/src/Lentille/GraphQL.hs
@@ -24,6 +24,7 @@ module Lentille.GraphQL (
   GraphResponse,
   GraphResp,
   GraphError,
+  DynErr (..),
   RateLimit (..),
   PageInfo (..),
   StreamFetchOptParams (..),
@@ -44,7 +45,9 @@ import Monocle.Effects
 
 type GraphEffects es = (LoggerEffect :> es, HttpEffect :> es, PrometheusEffect :> es, TimeEffect :> es, Retry :> es, Concurrent :> es, Fail :> es)
 
-type GraphResponse a = (PageInfo, Maybe RateLimit, [Text], a)
+data DynErr = NoRepo | UnknownErr [Text] | NoErr
+
+type GraphResponse a = (PageInfo, Maybe RateLimit, DynErr, a)
 
 -------------------------------------------------------------------------------
 -- Constants
@@ -201,7 +204,7 @@ streamFetch ::
   (Maybe Int -> Maybe Text -> Args a) ->
   StreamFetchOptParams es a ->
   -- | query result adapter
-  (a -> (PageInfo, Maybe RateLimit, [Text], [b])) ->
+  (a -> (PageInfo, Maybe RateLimit, DynErr, [b])) ->
   LentilleStream es b
 streamFetch client@GraphClient {..} mkArgs StreamFetchOptParams {..} transformResponse = startFetch
  where
@@ -268,7 +271,7 @@ streamFetch client@GraphClient {..} mkArgs StreamFetchOptParams {..} transformRe
       Left err ->
         -- Yield the error and stop the stream
         yieldStreamError $ RequestError (mkGraphQLError err)
-      Right (RequestResult mPartial (pageInfo, rateLimitM, decodingErrors, xs)) -> do
+      Right (RequestResult mPartial (pageInfo, rateLimitM, dynErrors, xs)) -> do
         -- Log crawling status
         logStep pageInfo rateLimitM xs totalFetched
 
@@ -276,8 +279,10 @@ streamFetch client@GraphClient {..} mkArgs StreamFetchOptParams {..} transformRe
           lift $ logWarn "Fetched partial result" ["err" .= partial]
           yieldStreamError $ PartialErrors partial
 
-        unless (null decodingErrors) do
-          yieldStreamError $ DecodeError decodingErrors
+        _ <- case dynErrors of
+          UnknownErr decodingErrors -> yieldStreamError $ DecodeError decodingErrors
+          NoRepo -> yieldStreamError $ EntityRemoved
+          NoErr -> pure ()
 
         -- Yield the results
         S.each (Right <$> xs)

--- a/src/Macroscope/Worker.hs
+++ b/src/Macroscope/Worker.hs
@@ -133,7 +133,7 @@ processStream logFunc postFunc = go (0 :: Word) [] []
       RequestError e -> ("graph", encodeJSON e)
       RateLimitInfoError e -> ("rate-limit-info", encodeJSON e)
       PartialErrors es -> ("partial", encodeJSON es)
-      EntityRemoved -> ("entity-removed", encodeJSON ("" :: Text))
+      EntityRemoved -> ("entity-removed", encodeJSON ("null" :: Text))
 
   processBatch :: [DocumentType] -> Eff es (Maybe ProcessError)
   processBatch [] = pure Nothing


### PR DESCRIPTION
When Monocle discovers organization's repositories it might happen that later repositories are deleted then the Changes crawler may encounter GraphQL queries issues. Such case in now handled and the stream silently continue on that case.

This effort could be subject to followup. But this first change might solve the issue #1112