### PR TITLE
elastic - bump from 7.17.16 to 7.17.26

### DIFF
--- a/.github/workflows/mkCI.dhall
+++ b/.github/workflows/mkCI.dhall
@@ -39,7 +39,7 @@ in  { GithubActions
       , GithubActions.Step::{
         , name = Some "Runs Elasticsearch"
         , uses = Some "elastic/elastic-github-actions/elasticsearch@master"
-        , `with` = Some (toMap { stack-version = "7.17.5" })
+        , `with` = Some (toMap { stack-version = "7.17.26" })
         }
       , GithubActions.Step::{
         , name = Some "Display indexes"

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Runs Elasticsearch
         uses: "elastic/elastic-github-actions/elasticsearch@master"
         with:
-          stack-version: "7.17.16"
+          stack-version: '7.17.26'
       - name: Display indexes
         run: curl -s -I -X GET http://localhost:9200/_cat/indices
       - name: Build the env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 ### Changed
+
+- [compose] Bumped Elasticsearch to 7.17.26.
+
 ### Removed
 ### Fixed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       retries: 6
       test: "curl --silent --fail localhost:9200/_cluster/health || exit 1"
       timeout: "60s"
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.16
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.26
     restart: unless-stopped
     ulimits:
       nofile:

--- a/k8s/elastic-deployment.yaml
+++ b/k8s/elastic-deployment.yaml
@@ -28,7 +28,7 @@ spec:
               value: -Xms512m -Xmx512m
             - name: discovery.type
               value: single-node
-          image: docker.elastic.co/elasticsearch/elasticsearch:7.17.16
+          image: docker.elastic.co/elasticsearch/elasticsearch:7.17.26
           livenessProbe:
             httpGet:
               path: /_cluster/health

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -105,12 +105,12 @@ in rec {
   arch = pkgs.lib.elemAt info 0;
   plat = pkgs.lib.elemAt info 1;
   elasticsearch = pkgsNonFree.elasticsearch7.overrideAttrs (old: rec {
-    version = "7.17.16";
+    version = "7.17.26";
     name = "elasticsearch-${version}";
     src = pkgs.fetchurl {
       url =
         "https://artifacts.elastic.co/downloads/elasticsearch/${name}-${plat}-${arch}.tar.gz";
-      sha256 = "o0ftRysyy1xp5M9bkKUZaQ2OvAnyHr6zCmoIPY0adZY=";
+      sha256 = "lUI+cWZMQ5Rm20Pj+bXH+62pQdf2+li3wrOgmpncYWE=";
     };
   });
   elasticsearch-home = "~/.local/share/monocle/elasticsearch-home";
@@ -355,12 +355,8 @@ in rec {
     exec ${pkgs.nodejs}/bin/npm start
   '';
 
-  services-req = [
-    kibanaStart
-    elasticsearchStart
-    monocleReplStart
-    monocleWebStart
-  ];
+  services-req =
+    [ kibanaStart elasticsearchStart monocleReplStart monocleWebStart ];
 
   # define the base requirements
   base-req = [ pkgs.bashInteractive hspkgs.coreutils pkgs.gnumake ];


### PR DESCRIPTION
This is the last Z release available for ElasticSearch.