### PR TITLE
Bump to ghc 9.6.6 from Nix latest

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,41 +1,22 @@
 {
   "nodes": {
-    "hspkgs": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      },
+    "latestnixpkgs": {
       "locked": {
-        "lastModified": 1711204635,
-        "narHash": "sha256-6nO2B9AZKbPKFO3FQGabrLGVTc1OkbprdCnGic+p6e4=",
-        "owner": "podenv",
-        "repo": "hspkgs",
-        "rev": "662e1c75a3b9a3873365b8cca041aaaa582e5c27",
+        "lastModified": 1735908276,
+        "narHash": "sha256-U19gzGJFlGtyNonhg3jhhamQUex5ri3MgR1QKz6w/qg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d3780c92e64472e8f9aa54f7bbb0dd4483b98303",
         "type": "github"
       },
       "original": {
-        "owner": "podenv",
-        "repo": "hspkgs",
-        "rev": "662e1c75a3b9a3873365b8cca041aaaa582e5c27",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d3780c92e64472e8f9aa54f7bbb0dd4483b98303",
         "type": "github"
       }
     },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1711196146,
-        "narHash": "sha256-SDB2EjSDfHzg4vbsoTOf8vGydJJfjNRHIQgkjVI1XMM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b79cc961fe98b158ea051ae3c71616872ffe8212",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b79cc961fe98b158ea051ae3c71616872ffe8212",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
       "locked": {
         "lastModified": 1652483617,
         "narHash": "sha256-Jxyn3uXFr5LdZNNiippI/obtLXAVBM18uVfiKVP4j9Q=",
@@ -53,8 +34,8 @@
     },
     "root": {
       "inputs": {
-        "hspkgs": "hspkgs",
-        "nixpkgs": "nixpkgs_2"
+        "latestnixpkgs": "latestnixpkgs",
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -5,33 +5,33 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1691350685,
-        "narHash": "sha256-Fdv6Xpc3SjheKcBCA+NEe3E6pX9wQ1ADhNv0UiM+VvA=",
+        "lastModified": 1711204635,
+        "narHash": "sha256-6nO2B9AZKbPKFO3FQGabrLGVTc1OkbprdCnGic+p6e4=",
         "owner": "podenv",
         "repo": "hspkgs",
-        "rev": "e25ca08431a6bab2b9eccda1764269824fe786ea",
+        "rev": "662e1c75a3b9a3873365b8cca041aaaa582e5c27",
         "type": "github"
       },
       "original": {
         "owner": "podenv",
         "repo": "hspkgs",
-        "rev": "e25ca08431a6bab2b9eccda1764269824fe786ea",
+        "rev": "662e1c75a3b9a3873365b8cca041aaaa582e5c27",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691280800,
-        "narHash": "sha256-/0CqbbXO5qfyZ2DgyLIYGP7wT3ONNE3gtiE5gYG9zXE=",
+        "lastModified": 1711196146,
+        "narHash": "sha256-SDB2EjSDfHzg4vbsoTOf8vGydJJfjNRHIQgkjVI1XMM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e365e1db48d060b3e31b02ec8177f66f386f39b8",
+        "rev": "b79cc961fe98b158ea051ae3c71616872ffe8212",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e365e1db48d060b3e31b02ec8177f66f386f39b8",
+        "rev": "b79cc961fe98b158ea051ae3c71616872ffe8212",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
     nixpkgs.url =
       "github:NixOS/nixpkgs/ed014c27f4d0ca772fb57d3b8985b772b0503bbd";
     hspkgs.url =
-      "github:podenv/hspkgs/e25ca08431a6bab2b9eccda1764269824fe786ea";
+      "github:podenv/hspkgs/662e1c75a3b9a3873365b8cca041aaaa582e5c27";
   };
 
   outputs = { self, nixpkgs, hspkgs }:

--- a/flake.nix
+++ b/flake.nix
@@ -24,15 +24,16 @@
   inputs = {
     nixpkgs.url =
       "github:NixOS/nixpkgs/ed014c27f4d0ca772fb57d3b8985b772b0503bbd";
-    hspkgs.url =
-      "github:podenv/hspkgs/662e1c75a3b9a3873365b8cca041aaaa582e5c27";
+    # Latest from https://github.com/NixOS/nixpkgs/tree/haskell-updates
+    latestnixpkgs.url =
+      "github:NixOS/nixpkgs/d3780c92e64472e8f9aa54f7bbb0dd4483b98303";
   };
 
-  outputs = { self, nixpkgs, hspkgs }:
+  outputs = { self, nixpkgs, latestnixpkgs }:
     let
       legacy = import ./nix/default.nix {
         nixpkgsPath = nixpkgs;
-        hspkgs = hspkgs.pkgs;
+        latestnixpkgsPath = latestnixpkgs;
         self = self;
       };
     in {

--- a/monocle.cabal
+++ b/monocle.cabal
@@ -136,7 +136,7 @@ library
                      , dhall-yaml                 >= 1.2
                      , directory
                      , either                     >= 5
-                     , effectful                  < 2.3.0.0
+                     , effectful                  < 2.4.0.0
                      , effectful-core
                      -- , effectful-plugin
                      , envparse                   >= 0.4

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -25,9 +25,9 @@ let
 
     # there is a test failure: resolveGroupController should resolve a direct mount root
     cgroup-rts-threads = pkgs.haskell.lib.dontCheck
-    (pkgs.haskell.lib.overrideCabal hpPrev.cgroup-rts-threads {
-      broken = false;
-    });
+      (pkgs.haskell.lib.overrideCabal hpPrev.cgroup-rts-threads {
+        broken = false;
+      });
 
     # Gerrit needs HEAD
     gerrit = let
@@ -40,11 +40,8 @@ let
     in hpPrev.callCabal2nix "gerrit" src { };
 
     # json-syntax test needs old tasty
-    json-syntax = pkgs.haskell.lib.doJailbreak
-    (pkgs.haskell.lib.dontCheck
-    (pkgs.haskell.lib.overrideCabal hpPrev.json-syntax {
-      broken = false;
-    }));
+    json-syntax = pkgs.haskell.lib.doJailbreak (pkgs.haskell.lib.dontCheck
+      (pkgs.haskell.lib.overrideCabal hpPrev.json-syntax { broken = false; }));
 
     # upgrade to bloodhound 0.20 needs some work
     bloodhound = pkgs.haskell.lib.overrideCabal hpPrev.bloodhound {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -23,6 +23,12 @@ let
   haskellExtend = hpFinal: hpPrev: {
     monocle = hpPrev.callCabal2nix "monocle" src { };
 
+    # there is a test failure: resolveGroupController should resolve a direct mount root
+    cgroup-rts-threads = pkgs.haskell.lib.dontCheck
+    (pkgs.haskell.lib.overrideCabal hpPrev.cgroup-rts-threads {
+      broken = false;
+    });
+
     # upgrade to bloodhound 0.20 needs some work
     bloodhound = pkgs.haskell.lib.overrideCabal hpPrev.bloodhound {
       version = "0.19.1.0";

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -384,7 +384,7 @@ in rec {
     [ kibanaStart elasticsearchStart monocleReplStart monocleWebStart ];
 
   # define the base requirements
-  base-req = [ pkgs.bashInteractive hsPkgs.coreutils pkgs.gnumake ];
+  base-req = [ pkgs.bashInteractive pkgs.coreutils pkgs.gnumake ];
   codegen-req = [ pkgs.protobuf pkgs.ocamlPackages.ocaml-protoc ] ++ base-req;
 
   hs-req = [

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -29,6 +29,23 @@ let
       broken = false;
     });
 
+    # Gerrit needs HEAD
+    gerrit = let
+      src = pkgs.fetchFromGitHub {
+        owner = "softwarefactory-project";
+        repo = "gerrit-haskell";
+        rev = "daa44c450f819f3af2879099ec065c1efb973ef8";
+        sha256 = "sha256-g+nMToAq1J8756Yres6xKraQq3QU3FcMjyLvaqVnrKc=";
+      };
+    in hpPrev.callCabal2nix "gerrit" src { };
+
+    # json-syntax test needs old tasty
+    json-syntax = pkgs.haskell.lib.doJailbreak
+    (pkgs.haskell.lib.dontCheck
+    (pkgs.haskell.lib.overrideCabal hpPrev.json-syntax {
+      broken = false;
+    }));
+
     # upgrade to bloodhound 0.20 needs some work
     bloodhound = pkgs.haskell.lib.overrideCabal hpPrev.bloodhound {
       version = "0.19.1.0";

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -72,14 +72,6 @@ let
     ];
   };
 
-  # pull latest nixpkgs for just [private] support
-  latestPkgsForJust = import (pkgs.fetchFromGitHub {
-    owner = "NixOS";
-    repo = "nixpkgs";
-    rev = "32ea06b23546a0172ac4e2aa733392e02f57503e";
-    sha256 = "sha256-NuRRuBO3ijXIu8sD9WaW5m6PHb3COI57UtHDMY+aGTI=";
-  }) { system = "x86_64-linux"; };
-
   # create the main package set without options
   pkgs = nixpkgsSrc { system = "x86_64-linux"; };
   latestPkgs = latestnixpkgsSrc { system = "x86_64-linux"; };
@@ -582,7 +574,7 @@ in rec {
     packages = p: [ (addExtraDeps p.monocle) p.pretty-simple ];
 
     buildInputs = [
-      latestPkgsForJust.just
+      latestPkgs.just
       hsPkgs.hlint
       hsPkgs.apply-refact
       hsPkgs.ghcid

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -29,7 +29,7 @@ import Monocle.Search.Query (parseDateValue)
 import Monocle.Version qualified
 import Options.Applicative hiding (header, help, str)
 import Options.Applicative qualified as O
-import Options.Applicative.Help.Pretty (string)
+import Options.Applicative.Help.Pretty (pretty)
 import Streaming.Prelude qualified as S
 
 import Data.String.Interpolate (i)
@@ -91,7 +91,7 @@ usage =
   usageCrawlerEnv = (,,) <$> envConf <*> envPublicUrl <*> envMonitoring
 
   -- Helper to create sub command
-  mkEnvDoc envParser = string (Env.helpDoc envParser)
+  mkEnvDoc envParser = pretty (Env.helpDoc envParser)
   mkCommand doc name parser envParser = command name $ info (parser <**> helper) (progDesc doc <> extraHelp)
    where
     -- We only add `--help` to sub command which uses environment

--- a/src/Json/Extras.hs
+++ b/src/Json/Extras.hs
@@ -5,7 +5,6 @@ module Json.Extras (
   -- * Data types
   module Json,
   ShortText,
-  TextShort.toText,
 
   -- * Extras
   decodeThrow,

--- a/src/Macroscope/Test.hs
+++ b/src/Macroscope/Test.hs
@@ -195,7 +195,7 @@ testGetStream = do
     (streams, clients) <- runStateT (traverse Macroscope.getCrawler (Macroscope.getCrawlers conf)) (Macroscope.Clients mempty mempty mempty)
     assertEqual' "Two streams created" 3 (length streams)
     assertEqual' "Only two gitlab clients created" 2 (length $ toList $ Macroscope.clientsGraph clients)
-    let expected = ["http://localhost--2790417469892086757 for crawler-for-org1, crawler-for-org2", "http://localhost--2790417469892086758 for crawler-for-org3"]
+    let expected = ["http://localhost--2888050933866766591 for crawler-for-org1, crawler-for-org2", "http://localhost--2888050933866766592 for crawler-for-org3"]
     assertEqual' "Stream group named" expected (map fst $ Macroscope.mkStreamsActions (catMaybes streams))
  where
   conf =

--- a/src/Monocle/Backend/Queries.hs
+++ b/src/Monocle/Backend/Queries.hs
@@ -10,6 +10,7 @@ import Data.List qualified
 import Data.Map qualified as Map
 import Data.Ord qualified
 import Data.String.Interpolate (i, iii)
+import Data.Text.Short qualified as TextShort
 import Data.Time (UTCTime (UTCTime), addDays, addGregorianMonthsClip, addGregorianYearsClip, secondsToNominalDiffTime)
 import Data.Time.Clock (secondsToDiffTime)
 import Data.Vector qualified as V
@@ -499,7 +500,7 @@ firstEventOnChanges = do
     let (createdAt, author) =
           -- If the event is older update the info
           if jceCreatedAt < feCreatedAt acc
-            then (jceCreatedAt, from $ Json.toText jceAuthor)
+            then (jceCreatedAt, from $ TextShort.toText jceAuthor)
             else (feCreatedAt acc, feAuthor acc)
      in FirstEvent
           { feChangeCreatedAt = jceOnCreatedAt

--- a/src/Monocle/Backend/Test.hs
+++ b/src/Monocle/Backend/Test.hs
@@ -32,8 +32,8 @@ import Relude.Unsafe ((!!))
 import Streaming.Prelude qualified as Streaming
 import Test.Tasty.HUnit ((@?=))
 
+import Effectful (UnliftStrategy(SeqUnlift))
 import Effectful.Fail qualified as E
-import Effectful (UnliftStrategy( SeqUnlift ))
 import Monocle.Backend.Queries (PeersStrengthMode (PSModeFilterOnAuthor, PSModeFilterOnPeer))
 import Monocle.Effects
 

--- a/src/Monocle/Backend/Test.hs
+++ b/src/Monocle/Backend/Test.hs
@@ -33,6 +33,7 @@ import Streaming.Prelude qualified as Streaming
 import Test.Tasty.HUnit ((@?=))
 
 import Effectful.Fail qualified as E
+import Effectful (UnliftStrategy( SeqUnlift ))
 import Monocle.Backend.Queries (PeersStrengthMode (PSModeFilterOnAuthor, PSModeFilterOnPeer))
 import Monocle.Effects
 
@@ -145,7 +146,7 @@ withTenantConfig :: Config.Index -> Eff [MonoQuery, ElasticEffect, LoggerEffect,
 withTenantConfig ws action = do
   bhEnv <- mkEnv'
   runEff $ runLoggerEffect $ runElasticEffect bhEnv $ runEmptyQueryM ws do
-    withEffToIO $ \runInIO ->
+    withEffToIO SeqUnlift $ \runInIO ->
       bracket_ (runInIO create) (runInIO delete) (runInIO action)
  where
   create = runRetry $ E.runFailIO $ dieOnEsError I.ensureIndex

--- a/src/Monocle/Backend/Test.hs
+++ b/src/Monocle/Backend/Test.hs
@@ -32,7 +32,7 @@ import Relude.Unsafe ((!!))
 import Streaming.Prelude qualified as Streaming
 import Test.Tasty.HUnit ((@?=))
 
-import Effectful (UnliftStrategy(SeqUnlift))
+import Effectful (UnliftStrategy (SeqUnlift))
 import Effectful.Fail qualified as E
 import Monocle.Backend.Queries (PeersStrengthMode (PSModeFilterOnAuthor, PSModeFilterOnPeer))
 import Monocle.Effects

--- a/src/Monocle/Logging.hs
+++ b/src/Monocle/Logging.hs
@@ -32,7 +32,7 @@ import Data.Aeson (Series, pairs)
 import Data.Aeson.Encoding (encodingToLazyByteString)
 import System.Log.FastLogger qualified as FastLogger
 
-import Effectful (Dispatch (Static), DispatchOf, Eff, Effect, IOE, withEffToIO, (:>))
+import Effectful (Dispatch (Static), DispatchOf, Eff, Effect, IOE, UnliftStrategy( SeqUnlift ), withEffToIO, (:>))
 import Effectful.Dispatch.Static (SideEffects (..), StaticRep, evalStaticRep, getStaticRep, localStaticRep, unsafeEff_)
 
 import Data.ByteString (ByteString)
@@ -122,7 +122,7 @@ newtype instance StaticRep LoggerEffect = LoggerEffect LoggerEnv
 runLoggerEffect :: IOE :> es => Eff (LoggerEffect : es) a -> Eff es a
 runLoggerEffect action =
   -- `withEffToIO` and `unInIO` enables calling IO function like: `(Logger -> IO a) -> IO a`.
-  withEffToIO $ \runInIO ->
+  withEffToIO SeqUnlift $ \runInIO ->
     withLogger \logger ->
       runInIO $ evalStaticRep (LoggerEffect logger) action
 

--- a/src/Monocle/Logging.hs
+++ b/src/Monocle/Logging.hs
@@ -32,7 +32,7 @@ import Data.Aeson (Series, pairs)
 import Data.Aeson.Encoding (encodingToLazyByteString)
 import System.Log.FastLogger qualified as FastLogger
 
-import Effectful (Dispatch (Static), DispatchOf, Eff, Effect, IOE, UnliftStrategy( SeqUnlift ), withEffToIO, (:>))
+import Effectful (Dispatch (Static), DispatchOf, Eff, Effect, IOE, UnliftStrategy (SeqUnlift), withEffToIO, (:>))
 import Effectful.Dispatch.Static (SideEffects (..), StaticRep, evalStaticRep, getStaticRep, localStaticRep, unsafeEff_)
 
 import Data.ByteString (ByteString)

--- a/src/Monocle/Main.hs
+++ b/src/Monocle/Main.hs
@@ -194,7 +194,7 @@ run' ApiConfig {..} aplogger = E.runConcurrent $ runLoggerEffect do
             . metricMiddleware
     logInfo "SystemReady" ["workspace" .= length workspaces, "port" .= port, "elastic" .= elasticUrl]
 
-    appEnv <- E.withEffToIO $ \effToIO -> do
+    appEnv <- E.withEffToIO E.SeqUnlift $ \effToIO -> do
       let configIO = effToIO getReloadConfig
       pure AppEnv {bhEnv, aOIDC, config = configIO}
 


### PR DESCRIPTION
First tentative to move our Haskell stack to a higher and stable version of the stack. We rely on podenv/hspkgs to provide a nix derivation for a Haskell package set.

Here we attempt a bump to hspkgs for ghc 9.6.4.