### PR TITLE
Increase the default Monocle.Client HTTP request timeout

### DIFF
--- a/src/Monocle/Client.hs
+++ b/src/Monocle/Client.hs
@@ -17,16 +17,16 @@ import Data.Text qualified as T
 import Monocle.Prelude
 import Network.HTTP.Client (
   Manager,
+  ManagerSettings (managerResponseTimeout),
   RequestBody (..),
   httpLbs,
   method,
   newManager,
-  ManagerSettings (managerResponseTimeout),
   parseRequest_,
   requestBody,
   requestHeaders,
   responseBody,
-  responseTimeoutMicro
+  responseTimeoutMicro,
  )
 import Network.HTTP.Client qualified
 import Network.HTTP.Client.OpenSSL qualified as OpenSSL


### PR DESCRIPTION
The default value of `Network.HTTP.Client` is 30 seconds, however we've spotted that some provider might have trouble to deal with complexes graphQL queries within that delay.

This change propose to double the value (60 seconds).