### PR TITLE
crawler - gitlab - lower the bulk amount of MR to fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - [compose] Bumped Elasticsearch to 7.17.26.
-- [crawler] Gitlab make Notes author attribute as nullable
+- [crawler] Gitlab - make Notes author attribute as nullable
+- [crawler] Gitlab - lower the bulk amount of MR objects to fetch from 100 to 25
 
 ### Removed
 ### Fixed

--- a/src/Lentille/GitLab/MergeRequests.hs
+++ b/src/Lentille/GitLab/MergeRequests.hs
@@ -32,7 +32,7 @@ declareLocalTypesInline
       project(fullPath: $project) {
         name
         nameWithNamespace
-        mergeRequests (first: 100, after: $cursor, sort: UPDATED_DESC, iids: $iids) {
+        mergeRequests (first: 25, after: $cursor, sort: UPDATED_DESC, iids: $iids) {
           pageInfo {hasNextPage endCursor}
           count
           nodes {


### PR DESCRIPTION
Be more respectful with regard to Gitlab provider as querying a large amount of data can raise 500 errors on Gitlab when responding to the graphQL query.

Ideally this value should be adaptative like for the Gitlab crawler, but let first decrease that value from 100 to 25.