### PR TITLE
Fixes https://github.com/change-metrics/monocle/issues/1128

### DIFF
--- a/codegen/MonocleCodegen.hs
+++ b/codegen/MonocleCodegen.hs
@@ -132,7 +132,7 @@ protoToReScript = fromProto headers mkService
     methodInput = "request: " <> msgName moduleName input
     methodOutput = "axios<" <> msgName moduleName output <> ">"
     requestEncode = "request->" <> moduleName <> "Bs.encode_" <> snake (attrName input)
-    requestCall = camel name <> "Raw(serverUrl ++ \"" <> path <> "\")"
+    requestCall = camel name <> "Raw(\"" <> path <> "\")"
     promiseDecode = "Js.Promise.then_(resp => { data: " <> decodeResponse <> "}->Js.Promise.resolve)"
     decodeResponse = "resp.data-> " <> moduleName <> "Bs.decode_" <> snake (attrName output)
 

--- a/web/src/App.res
+++ b/web/src/App.res
@@ -145,7 +145,7 @@ module Login = {
       let loginSubtitle =
         "Click on the button below to be redirected to identity provider." ++ " Once authenticated you'll be redirected to Monocle."
       let currentLocation = readWindowLocationFull()->Js.Global.encodeURIComponent
-      let location = WebApi.serverUrl ++ "/" ++ "api/2/auth/login?redirectUri=" ++ currentLocation
+      let location = WebApi.serverUrl ++ "/api/2/auth/login?redirectUri=" ++ currentLocation
       let onClick = e => {
         e->ReactEvent.Mouse.preventDefault
         replaceWindowLocation(location)

--- a/web/src/components/WebApi.res
+++ b/web/src/components/WebApi.res
@@ -17,7 +17,7 @@ module Login = {
     LoginTypes.login_validation_response,
   > =>
     request->LoginBs.encode_login_validation_request
-    |> loginValidationRaw(serverUrl ++ "/api/2/login/username/validate")
+    |> loginValidationRaw("/api/2/login/username/validate")
     |> Js.Promise.then_(resp =>
       {data: resp.data->LoginBs.decode_login_validation_response}->Js.Promise.resolve
     )
@@ -31,7 +31,7 @@ module Auth = {
     AuthTypes.get_magic_jwt_response,
   > =>
     request->AuthBs.encode_get_magic_jwt_request
-    |> getMagicJwtRaw(serverUrl ++ "/api/2/auth/get")
+    |> getMagicJwtRaw("/api/2/auth/get")
     |> Js.Promise.then_(resp =>
       {data: resp.data->AuthBs.decode_get_magic_jwt_response}->Js.Promise.resolve
     )
@@ -40,7 +40,7 @@ module Auth = {
 
   let whoAmi = (request: AuthTypes.who_ami_request): axios<AuthTypes.who_ami_response> =>
     request->AuthBs.encode_who_ami_request
-    |> whoAmiRaw(serverUrl ++ "/api/2/auth/whoami")
+    |> whoAmiRaw("/api/2/auth/whoami")
     |> Js.Promise.then_(resp =>
       {data: resp.data->AuthBs.decode_who_ami_response}->Js.Promise.resolve
     )
@@ -54,7 +54,7 @@ module Config = {
     ConfigTypes.get_workspaces_response,
   > =>
     request->ConfigBs.encode_get_workspaces_request
-    |> getWorkspacesRaw(serverUrl ++ "/api/2/get_workspaces")
+    |> getWorkspacesRaw("/api/2/get_workspaces")
     |> Js.Promise.then_(resp =>
       {data: resp.data->ConfigBs.decode_get_workspaces_response}->Js.Promise.resolve
     )
@@ -65,7 +65,7 @@ module Config = {
     ConfigTypes.get_projects_response,
   > =>
     request->ConfigBs.encode_get_projects_request
-    |> getProjectsRaw(serverUrl ++ "/api/2/get_projects")
+    |> getProjectsRaw("/api/2/get_projects")
     |> Js.Promise.then_(resp =>
       {data: resp.data->ConfigBs.decode_get_projects_response}->Js.Promise.resolve
     )
@@ -76,7 +76,7 @@ module Config = {
     ConfigTypes.get_groups_response,
   > =>
     request->ConfigBs.encode_get_groups_request
-    |> getGroupsRaw(serverUrl ++ "/api/2/get_groups")
+    |> getGroupsRaw("/api/2/get_groups")
     |> Js.Promise.then_(resp =>
       {data: resp.data->ConfigBs.decode_get_groups_response}->Js.Promise.resolve
     )
@@ -87,7 +87,7 @@ module Config = {
     ConfigTypes.get_group_members_response,
   > =>
     request->ConfigBs.encode_get_group_members_request
-    |> getGroupMembersRaw(serverUrl ++ "/api/2/get_group_members")
+    |> getGroupMembersRaw("/api/2/get_group_members")
     |> Js.Promise.then_(resp =>
       {data: resp.data->ConfigBs.decode_get_group_members_response}->Js.Promise.resolve
     )
@@ -96,7 +96,7 @@ module Config = {
 
   let getAbout = (request: ConfigTypes.get_about_request): axios<ConfigTypes.get_about_response> =>
     request->ConfigBs.encode_get_about_request
-    |> getAboutRaw(serverUrl ++ "/api/2/about")
+    |> getAboutRaw("/api/2/about")
     |> Js.Promise.then_(resp =>
       {data: resp.data->ConfigBs.decode_get_about_response}->Js.Promise.resolve
     )
@@ -110,7 +110,7 @@ module Search = {
     SearchTypes.suggestions_response,
   > =>
     request->SearchBs.encode_suggestions_request
-    |> suggestionsRaw(serverUrl ++ "/api/2/suggestions")
+    |> suggestionsRaw("/api/2/suggestions")
     |> Js.Promise.then_(resp =>
       {data: resp.data->SearchBs.decode_suggestions_response}->Js.Promise.resolve
     )
@@ -119,7 +119,7 @@ module Search = {
 
   let fields = (request: SearchTypes.fields_request): axios<SearchTypes.fields_response> =>
     request->SearchBs.encode_fields_request
-    |> fieldsRaw(serverUrl ++ "/api/2/search/fields")
+    |> fieldsRaw("/api/2/search/fields")
     |> Js.Promise.then_(resp =>
       {data: resp.data->SearchBs.decode_fields_response}->Js.Promise.resolve
     )
@@ -128,7 +128,7 @@ module Search = {
 
   let check = (request: SearchTypes.check_request): axios<SearchTypes.check_response> =>
     request->SearchBs.encode_check_request
-    |> checkRaw(serverUrl ++ "/api/2/search/check")
+    |> checkRaw("/api/2/search/check")
     |> Js.Promise.then_(resp =>
       {data: resp.data->SearchBs.decode_check_response}->Js.Promise.resolve
     )
@@ -137,7 +137,7 @@ module Search = {
 
   let query = (request: SearchTypes.query_request): axios<SearchTypes.query_response> =>
     request->SearchBs.encode_query_request
-    |> queryRaw(serverUrl ++ "/api/2/search/query")
+    |> queryRaw("/api/2/search/query")
     |> Js.Promise.then_(resp =>
       {data: resp.data->SearchBs.decode_query_response}->Js.Promise.resolve
     )
@@ -146,7 +146,7 @@ module Search = {
 
   let author = (request: SearchTypes.author_request): axios<SearchTypes.author_response> =>
     request->SearchBs.encode_author_request
-    |> authorRaw(serverUrl ++ "/api/2/search/author")
+    |> authorRaw("/api/2/search/author")
     |> Js.Promise.then_(resp =>
       {data: resp.data->SearchBs.decode_author_response}->Js.Promise.resolve
     )
@@ -158,7 +158,7 @@ module Metric = {
 
   let list = (request: MetricTypes.list_request): axios<MetricTypes.list_response> =>
     request->MetricBs.encode_list_request
-    |> listRaw(serverUrl ++ "/api/2/metric/list")
+    |> listRaw("/api/2/metric/list")
     |> Js.Promise.then_(resp =>
       {data: resp.data->MetricBs.decode_list_response}->Js.Promise.resolve
     )
@@ -167,14 +167,14 @@ module Metric = {
 
   let get = (request: MetricTypes.get_request): axios<MetricTypes.get_response> =>
     request->MetricBs.encode_get_request
-    |> getRaw(serverUrl ++ "/api/2/metric/get")
+    |> getRaw("/api/2/metric/get")
     |> Js.Promise.then_(resp => {data: resp.data->MetricBs.decode_get_response}->Js.Promise.resolve)
   @module("axios")
   external infoRaw: (string, 'a) => axios<'b> = "post"
 
   let info = (request: MetricTypes.info_request): axios<MetricTypes.info_response> =>
     request->MetricBs.encode_info_request
-    |> infoRaw(serverUrl ++ "/api/2/metric/info")
+    |> infoRaw("/api/2/metric/info")
     |> Js.Promise.then_(resp =>
       {data: resp.data->MetricBs.decode_info_response}->Js.Promise.resolve
     )
@@ -186,7 +186,7 @@ module Crawler = {
 
   let addDoc = (request: CrawlerTypes.add_doc_request): axios<CrawlerTypes.add_doc_response> =>
     request->CrawlerBs.encode_add_doc_request
-    |> addDocRaw(serverUrl ++ "/api/2/crawler/add")
+    |> addDocRaw("/api/2/crawler/add")
     |> Js.Promise.then_(resp =>
       {data: resp.data->CrawlerBs.decode_add_doc_response}->Js.Promise.resolve
     )
@@ -195,7 +195,7 @@ module Crawler = {
 
   let commit = (request: CrawlerTypes.commit_request): axios<CrawlerTypes.commit_response> =>
     request->CrawlerBs.encode_commit_request
-    |> commitRaw(serverUrl ++ "/api/2/crawler/commit")
+    |> commitRaw("/api/2/crawler/commit")
     |> Js.Promise.then_(resp =>
       {data: resp.data->CrawlerBs.decode_commit_response}->Js.Promise.resolve
     )
@@ -206,7 +206,7 @@ module Crawler = {
     CrawlerTypes.commit_info_response,
   > =>
     request->CrawlerBs.encode_commit_info_request
-    |> commitInfoRaw(serverUrl ++ "/api/2/crawler/get_commit_info")
+    |> commitInfoRaw("/api/2/crawler/get_commit_info")
     |> Js.Promise.then_(resp =>
       {data: resp.data->CrawlerBs.decode_commit_info_response}->Js.Promise.resolve
     )
@@ -215,7 +215,7 @@ module Crawler = {
 
   let errors = (request: CrawlerTypes.errors_request): axios<CrawlerTypes.errors_response> =>
     request->CrawlerBs.encode_errors_request
-    |> errorsRaw(serverUrl ++ "/api/2/crawler/errors")
+    |> errorsRaw("/api/2/crawler/errors")
     |> Js.Promise.then_(resp =>
       {data: resp.data->CrawlerBs.decode_errors_response}->Js.Promise.resolve
     )


### PR DESCRIPTION
Fixed redundant slash issue in App.res:

Changed WebApi.serverUrl ++ "/" ++ "api/2/auth/login?redirectUri=" to WebApi.serverUrl ++ "/api/2/auth/login?redirectUri="
Modified code generation in MonocleCodegen.hs:

Changed requestCall = camel name <> "Raw(serverUrl ++ \"" <> path <> "\")" to requestCall = camel name <> "Raw(\"" <> path <> "\")"
This ensures that the generated ReScript code uses direct API paths
Updated all API calls in WebApi.res to use direct paths:

Modified all modules (Login, Auth, Config, Search, Metric, Crawler)
Changed from methodRaw(serverUrl ++ "/api/2/path") to methodRaw("/api/2/path")
All 20 API endpoints now use direct paths
This approach has several benefits:

Prevents issues with double slashes or incorrect URL construction
Makes the code more maintainable and easier to understand
Follows web standards where paths like "/api/2/auth/get" are resolved relative to the current origin

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>
