### PR TITLE
Add `content-type` Header to served files

### DIFF
--- a/monocle.cabal
+++ b/monocle.cabal
@@ -142,6 +142,7 @@ library
                      , envparse                   < 1
                      , exceptions                 >= 0.10
                      , fakedata                   >= 1.0
+                     , filepath
                      , fast-logger
                      , foldl
                      , gerrit                     >= 0.1.6


### PR DESCRIPTION
## Content-type Missing
Currently when I serve the application through [Tailscale Serve](https://tailscale.com/docs/features/tailscale-serve) the content type for all files get defaulted to `text/plain` since they are not present. When I updated tailscale on my server, it broke Monocle not allowing any CSS or Javascript to load since the content-types were not set. 

This PR adds content types for all the static files being served by Monocle.


| Served Locally | Tailscale Serve |
|--|--|
|<img width="511" height="316" alt="Screenshot 2026-02-18 at 12 18 00 PM" src="https://github.com/user-attachments/assets/16ccb39c-c69a-4e03-919c-9ab1883fd22f" />|<img width="511" height="316" alt="Screenshot 2026-02-18 at 12 17 41 PM" src="https://github.com/user-attachments/assets/c13f27ac-ccc1-43ab-b952-4b6f20c774e9" />|


This pull request ensures that the content-type is always served for all files types in the project:
| Tailscale Serve after fix |
| --- |
|<img width="721" height="255" alt="Screenshot 2026-02-19 at 11 32 10 AM" src="https://github.com/user-attachments/assets/e59aed5d-8fcb-41ae-ae81-f1bbef4f8cd2" />|

<img width="1669" height="686" alt="Screenshot 2026-02-18 at 11 10 40 AM" src="https://github.com/user-attachments/assets/11de0182-3817-45f5-b39c-2908cbb25def" />

Working Dashboard:

<img width="1668" height="970" alt="Screenshot 2026-02-19 at 11 32 24 AM" src="https://github.com/user-attachments/assets/030f38c4-aa1c-479a-b1a8-ac68b085710d" />