### PR TITLE
Fix default config

### DIFF
--- a/schemas/monocle/config/Crawlers/default.dhall
+++ b/schemas/monocle/config/Crawlers/default.dhall
@@ -1,1 +1,1 @@
-{ loop_delay_sec : None Natural }
+{ loop_delay_sec = None Natural }


### PR DESCRIPTION
This change fixes the following error when using the schema:

  Error: Invalid field type

  1│ { loop_delay_sec : None Natural }